### PR TITLE
#8 #9 disable adding `.git` during `Dockerfile` steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ADD composer.lock /app/composer.lock
 
 RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --no-autoloader
 
-ADD .git /app/.git
+# @TODO https://github.com/laminas/automatic-releases/issues/8 we skip `.git` for now, as it isn't available in the build environment
+# @TODO https://github.com/laminas/automatic-releases/issues/9 we skip `.git` for now, as it isn't available in the build environment
+#ADD .git /app/.git
 ADD bin /app/bin
 ADD src /app/src
 


### PR DESCRIPTION
This fixes #8, but skips version rendering in our CLI: that's
an acceptable tradeoff, for now: we'll need to fix this later,
when we work on #9 (or eventually consider dropping this code
entirely).
