### PR TITLE
#11 - create+switch default branch on release

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -35,3 +35,13 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create and/or Switch to new Release Branch"
+        uses: "./"
+        with:
+          command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ to your project or organisation:
  * `GIT_AUTHOR_EMAIL` - email address of the author of your releases: can be an email address of a bot account.
  * `SIGNING_SECRET_KEY` - a **password-less** private GPG key in ASCII format, to be used for signing your releases:
    please use a dedicated GPG subkey for this purpose. Unsigned releases are not supported, and won't be supported.
+ * `ORGANIZATION_ADMIN_TOKEN` - if you use the file from [`examples/.github/workflows/release-on-milestone-closed.yml`](examples/.github/workflows/release-on-milestone-closed.yml),
+   then you have to provide a `ORGANIZATION_ADMIN_TOKEN`, which is a github token with administrative rights over
+   your organisation. This is required for the `laminas:automatic-releases:switch-default-branch-to-next-minor`
+   command, because [changing default branch of a repository currently requires administrative token rights](https://developer.github.com/v3/repos/#update-a-repository).
+   You can generate a token from your [personal access tokens page](https://github.com/settings/tokens/new).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ to your project or organisation:
    please use a dedicated GPG subkey for this purpose. Unsigned releases are not supported, and won't be supported.
  * `ORGANIZATION_ADMIN_TOKEN` - if you use the file from [`examples/.github/workflows/release-on-milestone-closed.yml`](examples/.github/workflows/release-on-milestone-closed.yml),
    then you have to provide a `ORGANIZATION_ADMIN_TOKEN`, which is a github token with administrative rights over
-   your organisation. This is required for the `laminas:automatic-releases:switch-default-branch-to-next-minor`
+   your organisation (issued by a user that has administrative rights over your project).
+   This is required for the `laminas:automatic-releases:switch-default-branch-to-next-minor`
    command, because [changing default branch of a repository currently requires administrative token rights](https://developer.github.com/v3/repos/#update-a-repository).
    You can generate a token from your [personal access tokens page](https://github.com/settings/tokens/new).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ this action will perform all following steps (or stop with an error):
  5. create a tag named `x.y.z` on the selected branch, with the generated changelog
  6. publish a release named `x.y.z`, with the generated tag and changelog
  7. create (if applicable), a pull request from the selected branch to the next release branch
+ 8. create (if necessary) a "next minor" release branch `x.y+1.z`
+ 9. switch default repository branch to newest release branch
 
 Please read the [`feature/`](./feature) specification for more detailed scenarios on how the tool is supposed
 to operate.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,11 @@ description: 'Automates automatic releases for semver-compliant repositories'
 
 inputs:
   command-name:
-    description: 'Command to execute: one of "laminas:automatic-releases:release" or "laminas:automatic-releases:create-merge-up-pull-request"'
+    description: |
+      Command to execute: one of
+       * `laminas:automatic-releases:release`
+       * `laminas:automatic-releases:create-merge-up-pull-request`
+       * `laminas:automatic-releases:switch-default-branch-to-next-minor`
     required: true
 
 runs:

--- a/bin/console.php
+++ b/bin/console.php
@@ -10,6 +10,7 @@ use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Laminas\AutomaticReleases\Application\Command\CreateMergeUpPullRequest;
 use Laminas\AutomaticReleases\Application\Command\ReleaseCommand;
+use Laminas\AutomaticReleases\Application\Command\SwitchDefaultBranchToNextMinor;
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
 use Laminas\AutomaticReleases\Git\CreateTagViaConsole;
 use Laminas\AutomaticReleases\Git\FetchAndSetCurrentUserByReplacingCurrentOriginRemote;
@@ -19,6 +20,7 @@ use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneFirst100Issue
 use Laminas\AutomaticReleases\Github\Api\GraphQL\RunGraphQLQuery;
 use Laminas\AutomaticReleases\Github\Api\V3\CreatePullRequestThroughApiCall;
 use Laminas\AutomaticReleases\Github\Api\V3\CreateReleaseThroughApiCall;
+use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranchThroughApiCall;
 use Laminas\AutomaticReleases\Github\CreateReleaseTextThroughChangelog;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEventFromGithubActionPath;
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
@@ -88,6 +90,18 @@ use const E_WARNING;
             $createReleaseText,
             $push,
             new CreatePullRequestThroughApiCall(
+                $makeRequests,
+                $httpClient,
+                $githubToken
+            )
+        ),
+        new SwitchDefaultBranchToNextMinor(
+            $variables,
+            $loadEvent,
+            $fetch,
+            $getCandidateBranches,
+            $push,
+            new SetDefaultBranchThroughApiCall(
                 $makeRequests,
                 $httpClient,
                 $githubToken

--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -17,7 +17,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "laminas/automatic-releases@v1"
+        uses: "laminas/automatic-releases@v1.0.0"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -27,7 +27,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@v1"
+        uses: "laminas/automatic-releases@v1.0.0"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
@@ -37,11 +37,11 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create and/or Switch to new Release Branch"
-        uses: "laminas/automatic-releases@v1"
+        uses: "laminas/automatic-releases@v1.0.0"
         with:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -35,3 +35,13 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create and/or Switch to new Release Branch"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -51,7 +51,9 @@ Feature: Automated releases
     When I close milestone "1.1.0"
     Then the tool should have halted with an error
 
-  Scenario: If a minor release branch exists, the tool creates a new minor release from there
+  Scenario: If a minor release branch exists, when closing the minor release milestone,
+  the tool tags the minor release from the branch, and creates a pull request
+  against the next newer minor release branch.
     Given following existing branches:
       | name   |
       | 1.1.x  |

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -3,8 +3,10 @@ Feature: Automated releases
 
   Scenario: If no major release branch exists, the tool should not create a new major release
     Given following existing branches:
-      | name  |
-      | 1.0.x |
+      | name    |
+      | 1.0.x   |
+      | master  |
+      | develop |
     And following open milestones:
       | name  |
       | 2.0.0 |
@@ -13,8 +15,10 @@ Feature: Automated releases
 
   Scenario: If no major release branch exists, the tool should not create a new minor release
     Given following existing branches:
-      | name  |
-      | 1.0.x |
+      | name    |
+      | 1.0.x   |
+      | master  |
+      | develop |
     And following open milestones:
       | name  |
       | 1.1.0 |
@@ -23,9 +27,11 @@ Feature: Automated releases
 
   Scenario: If a major release branch exists, the tool creates a major release from there
     Given following existing branches:
-      | name   |
-      | 1.0.x  |
-      | master |
+      | name    |
+      | 1.0.x   |
+      | 2.0.x   |
+      | master  |
+      | develop |
     And following open milestones:
       | name  |
       | 2.0.0 |
@@ -33,29 +39,44 @@ Feature: Automated releases
     Then tag "2.0.0" should have been created on branch "master"
     And branch "2.0.x" should have been created from "master"
 
-  Scenario: If a major release branch exists, the tool creates a new minor release from there
+  Scenario: If a new major release branch exists, the tool does not create a new minor release
     Given following existing branches:
-      | name   |
-      | 1.0.x  |
-      | master |
+      | name    |
+      | 1.0.x   |
+      | 2.0.x   |
+      | master  |
+      | develop |
     And following open milestones:
       | name  |
       | 1.1.0 |
     When I close milestone "1.1.0"
-    Then tag "1.1.0" should have been created on branch "master"
-    And branch "1.1.x" should have been created from "master"
+    Then the tool should have halted with an error
 
   Scenario: If a minor release branch exists, the tool creates a new minor release from there
     Given following existing branches:
       | name   |
       | 1.1.x  |
+      | 1.2.x  |
       | master |
     And following open milestones:
       | name  |
       | 1.1.0 |
     When I close milestone "1.1.0"
     Then tag "1.1.0" should have been created on branch "1.1.x"
-    And a new pull request from branch "1.1.x" to "master" should have been created
+    And a new pull request from branch "1.1.x" to "1.2.x" should have been created
+
+  Scenario: If a no newer release branch exists, the tool will not create a pull request against it
+    Given following existing branches:
+      | name    |
+      | 1.1.x   |
+      | master  |
+      | develop |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then tag "1.1.0" should have been created on branch "1.1.x"
+    And no new pull request should have been created
 
   Scenario: If a minor release branch exists, the tool creates a new patch release from there
     Given following existing branches:

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -36,8 +36,7 @@ Feature: Automated releases
       | name  |
       | 2.0.0 |
     When I close milestone "2.0.0"
-    Then tag "2.0.0" should have been created on branch "master"
-    And branch "2.0.x" should have been created from "master"
+    Then tag "2.0.0" should have been created on branch "2.0.x"
 
   Scenario: If a new major release branch exists, the tool does not create a new minor release
     Given following existing branches:

--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -65,7 +65,7 @@ Feature: Automated releases
     Then tag "1.1.0" should have been created on branch "1.1.x"
     And a new pull request from branch "1.1.x" to "1.2.x" should have been created
 
-  Scenario: If a no newer release branch exists, the tool will not create a pull request against it
+  Scenario: If no newer release branch exists, the tool will not create any pull requests
     Given following existing branches:
       | name    |
       | 1.1.x   |

--- a/feature/default-branch-switching.feature
+++ b/feature/default-branch-switching.feature
@@ -20,7 +20,7 @@ Feature: Default branch switching
       | 1.3.x  |
     And the default branch should be "1.3.x"
 
-  Scenario: A pre-existing minor release branch is set as default branch on release
+  Scenario: The latest pre-existing minor release branch is set as default branch on a successful release
     Given following existing branches:
       | branch |
       | 1.0.x  |
@@ -81,5 +81,4 @@ Feature: Default branch switching
       | master  |
       | develop |
     And the default branch should be "develop"
-
 

--- a/feature/default-branch-switching.feature
+++ b/feature/default-branch-switching.feature
@@ -1,0 +1,85 @@
+@manually-tested
+Feature: Default branch switching
+
+  Scenario: A new minor branch is created and set as default branch on release
+    Given following existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+    And following open milestones:
+      | name  |
+      | 1.2.0 |
+    And the default branch is "1.0.x"
+    When I close milestone "1.2.0"
+    Then these should be the existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 1.3.x  |
+    And the default branch should be "1.3.x"
+
+  Scenario: A pre-existing minor release branch is set as default branch on release
+    Given following existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 1.3.x  |
+    And following open milestones:
+      | name  |
+      | 1.2.0 |
+    And the default branch is "1.0.x"
+    When I close milestone "1.2.0"
+    Then these should be the existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 1.3.x  |
+    And the default branch should be "1.3.x"
+
+  Scenario: A pre-existing branch of a greater major release is set as default branch on release
+    Given following existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 2.0.x  |
+      | 2.1.x  |
+    And following open milestones:
+      | name  |
+      | 1.2.0 |
+    And the default branch is "1.0.x"
+    When I close milestone "1.2.0"
+    Then these should be the existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 2.0.x  |
+      | 2.1.x  |
+    And the default branch should be "2.1.x"
+
+  Scenario: Branch is not switched when no minor release branch exists
+    Given following existing branches:
+      | branch  |
+      | foo     |
+      | bar     |
+      | master  |
+      | develop |
+    And following open milestones:
+      | name  |
+      | 1.2.0 |
+    And the default branch is "develop"
+    When I close milestone "1.2.0"
+    Then these should be the existing branches:
+      | branch  |
+      | foo     |
+      | bar     |
+      | master  |
+      | develop |
+    And the default branch should be "develop"
+
+

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -14,6 +14,6 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 59,
-    "minCoveredMsi": 59
+    "minMsi": 62,
+    "minCoveredMsi": 62
 }

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Application\Command;
+
+use Laminas\AutomaticReleases\Environment\Variables;
+use Laminas\AutomaticReleases\Git\Fetch;
+use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Git\Push;
+use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranch;
+use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+final class SwitchDefaultBranchToNextMinor extends Command
+{
+    private Variables $variables;
+    private LoadCurrentGithubEvent $loadGithubEvent;
+    private Fetch $fetch;
+    private GetMergeTargetCandidateBranches $getMergeCandidates;
+    private Push $push;
+    private SetDefaultBranch $switchDefaultBranch;
+
+    public function __construct(
+        Variables $variables,
+        LoadCurrentGithubEvent $loadGithubEvent,
+        Fetch $fetch,
+        GetMergeTargetCandidateBranches $getMergeCandidates,
+        Push $push,
+        SetDefaultBranch $switchDefaultBranch
+    ) {
+        parent::__construct('laminas:automatic-releases:switch-default-branch-to-next-minor');
+
+        $this->variables           = $variables;
+        $this->loadGithubEvent     = $loadGithubEvent;
+        $this->fetch               = $fetch;
+        $this->getMergeCandidates  = $getMergeCandidates;
+        $this->push                = $push;
+        $this->switchDefaultBranch = $switchDefaultBranch;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $event          = $this->loadGithubEvent->__invoke();
+        $repositoryPath = $this->variables->githubWorkspacePath();
+
+        Assert::directory($repositoryPath . '/.git');
+
+        $this->fetch->__invoke(
+            $event->repository()
+                ->uriWithTokenAuthentication($this->variables->githubToken()),
+            $repositoryPath
+        );
+
+        $mergeCandidates = $this->getMergeCandidates->__invoke($repositoryPath);
+        $releaseVersion  = $event->version();
+        $newestBranch    = $mergeCandidates->newestReleaseBranch();
+
+        if ($newestBranch === null) {
+            $output->writeln('No stable branches found: cannot switch default branch');
+
+            return 0;
+        }
+
+        $nextDefaultBranch = $mergeCandidates->newestFutureReleaseBranchAfter($releaseVersion);
+
+        if (! $mergeCandidates->contains($nextDefaultBranch)) {
+            $this->push->__invoke(
+                $repositoryPath,
+                $newestBranch->name(),
+                $nextDefaultBranch->name()
+            );
+        }
+
+        $this->switchDefaultBranch->__invoke($event->repository(), $nextDefaultBranch);
+
+        return 0;
+    }
+}

--- a/src/Git/Value/BranchName.php
+++ b/src/Git/Value/BranchName.php
@@ -65,7 +65,7 @@ final class BranchName
         return [$major, $minor];
     }
 
-    public function targetVersion(): SemVerVersion
+    public function targetMinorReleaseVersion(): SemVerVersion
     {
         [$major, $minor] = $this->majorAndMinor();
 

--- a/src/Git/Value/BranchName.php
+++ b/src/Git/Value/BranchName.php
@@ -70,6 +70,13 @@ final class BranchName
         return [$major, $minor];
     }
 
+    public function targetVersion(): SemVerVersion
+    {
+        [$major, $minor] = $this->majorAndMinor();
+
+        return SemVerVersion::fromMilestoneName($major . '.' . $minor . '.0');
+    }
+
     public function equals(self $other): bool
     {
         return $other->name === $this->name;

--- a/src/Git/Value/BranchName.php
+++ b/src/Git/Value/BranchName.php
@@ -45,11 +45,6 @@ final class BranchName
         return preg_match('/^(v)?\d+\\.\d+(\\.x)?$/', $this->name) === 1;
     }
 
-    public function isNextMajor(): bool
-    {
-        return $this->name === 'master';
-    }
-
     /**
      * @return array<int, int>
      *

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -97,7 +97,7 @@ final class MergeTargetCandidateBranches
         return array_filter(
             array_reverse($this->sortedBranches),
             static function (BranchName $branch) use ($nextMinor): bool {
-                return $nextMinor->lessThanEqual($branch->targetVersion());
+                return $nextMinor->lessThanEqual($branch->targetMinorReleaseVersion());
             }
         )[0] ?? $nextMinor->targetReleaseBranchName();
     }

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git\Value;
 
-use Webmozart\Assert\Assert;
-
 use function array_filter;
 use function array_reverse;
 use function array_search;
@@ -17,13 +15,16 @@ use function Safe\usort;
 
 final class MergeTargetCandidateBranches
 {
-    /** @var BranchName[] branches that can be used for releases, sorted in ascending version number */
+    /**
+     * @var BranchName[] branches that can be used for releases, sorted in ascending version number
+     * @psalm-var list<BranchName>
+     */
     private array $sortedBranches;
 
     /**
      * @param BranchName[] $sortedBranches
      *
-     * @psalm-param non-empty-list<BranchName> $sortedBranches
+     * @psalm-param list<BranchName> $sortedBranches
      */
     private function __construct(array $sortedBranches)
     {
@@ -33,21 +34,10 @@ final class MergeTargetCandidateBranches
     public static function fromAllBranches(BranchName ...$branches): self
     {
         $mergeTargetBranches = array_filter($branches, static function (BranchName $branch): bool {
-            return $branch->isReleaseBranch()
-                || $branch->isNextMajor();
+            return $branch->isReleaseBranch();
         });
 
-        Assert::notEmpty($mergeTargetBranches);
-
         usort($mergeTargetBranches, static function (BranchName $a, BranchName $b): int {
-            if ($a->isNextMajor()) {
-                return 1;
-            }
-
-            if ($b->isNextMajor()) {
-                return -1;
-            }
-
             return $a->majorAndMinor() <=> $b->majorAndMinor();
         });
 
@@ -58,14 +48,6 @@ final class MergeTargetCandidateBranches
     public function targetBranchFor(SemVerVersion $version): ?BranchName
     {
         foreach ($this->sortedBranches as $branch) {
-            if ($branch->isNextMajor()) {
-                if (! $version->isNewMinorRelease()) {
-                    return null;
-                }
-
-                return $branch;
-            }
-
             if ($branch->isForNewerVersionThan($version)) {
                 return null;
             }
@@ -103,33 +85,21 @@ final class MergeTargetCandidateBranches
             : $branch;
     }
 
-    /** @TODO move `master` exclusion into ctor - `master` is no longer a valid release branch */
     public function newestReleaseBranch(): ?BranchName
     {
-        return array_values(array_filter(
-            array_reverse($this->sortedBranches),
-            static fn (BranchName $branch): bool => $branch->name() !== 'master'
-        ))[0] ?? null;
+        return array_reverse($this->sortedBranches)[0] ?? null;
     }
 
-    /** @TODO move `master` exclusion into ctor - `master` is no longer a valid release branch */
     public function newestFutureReleaseBranchAfter(SemVerVersion $version): BranchName
     {
         $nextMinor = $version->nextMinor();
 
-        foreach (array_reverse($this->sortedBranches) as $branch) {
-            if ($branch->name() === 'master') {
-                continue; // For now, we skip `master` here - no longer a valid release branch for us
+        return array_filter(
+            array_reverse($this->sortedBranches),
+            static function (BranchName $branch) use ($nextMinor): bool {
+                return $nextMinor->lessThanEqual($branch->targetVersion());
             }
-
-            if ($nextMinor->lessThanEqual($branch->targetVersion())) {
-                return $branch;
-            }
-
-            break;
-        }
-
-        return $nextMinor->targetReleaseBranchName();
+        )[0] ?? $nextMinor->targetReleaseBranchName();
     }
 
     public function contains(BranchName $needle): bool

--- a/src/Git/Value/SemVerVersion.php
+++ b/src/Git/Value/SemVerVersion.php
@@ -54,6 +54,11 @@ final class SemVerVersion
         return $this->minor;
     }
 
+    public function nextMinor(): self
+    {
+        return new self($this->major, $this->minor + 1, 0);
+    }
+
     public function targetReleaseBranchName(): BranchName
     {
         return BranchName::fromName($this->major . '.' . $this->minor . '.x');
@@ -62,5 +67,10 @@ final class SemVerVersion
     public function isNewMinorRelease(): bool
     {
         return $this->patch === 0;
+    }
+
+    public function lessThanEqual(self $other): bool
+    {
+        return $this->fullReleaseName() <= $other->fullReleaseName();
     }
 }

--- a/src/Github/Api/V3/SetDefaultBranch.php
+++ b/src/Github/Api/V3/SetDefaultBranch.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Github\Api\V3;
+
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+
+interface SetDefaultBranch
+{
+    /** @psalm-param non-empty-string $title */
+    public function __invoke(
+        RepositoryName $repository,
+        BranchName $defaultBranch
+    ): void;
+}

--- a/src/Github/Api/V3/SetDefaultBranchThroughApiCall.php
+++ b/src/Github/Api/V3/SetDefaultBranchThroughApiCall.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Github\Api\V3;
+
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Webmozart\Assert\Assert;
+
+use function Safe\json_decode;
+use function Safe\json_encode;
+
+final class SetDefaultBranchThroughApiCall implements SetDefaultBranch
+{
+    private const API_ROOT = 'https://api.github.com/';
+
+    private RequestFactoryInterface $messageFactory;
+
+    private ClientInterface $client;
+
+    private string $apiToken;
+
+    /** @psalm-param non-empty-string $apiToken */
+    public function __construct(
+        RequestFactoryInterface $messageFactory,
+        ClientInterface $client,
+        string $apiToken
+    ) {
+        $this->messageFactory = $messageFactory;
+        $this->client         = $client;
+        $this->apiToken       = $apiToken;
+    }
+
+    public function __invoke(
+        RepositoryName $repository,
+        BranchName $defaultBranch
+    ): void {
+        $request = $this->messageFactory
+            ->createRequest(
+                'PATCH',
+                self::API_ROOT . 'repos/' . $repository->owner() . '/' . $repository->name()
+            )
+            ->withAddedHeader('Content-Type', 'application/json')
+            ->withAddedHeader('User-Agent', 'Ocramius\'s minimal API V3 client')
+            ->withAddedHeader('Authorization', 'bearer ' . $this->apiToken);
+
+        $request
+            ->getBody()
+            ->write(json_encode(['default_branch' => $defaultBranch->name()]));
+
+        $response = $this->client->sendRequest($request);
+
+        $responseBody = $response
+            ->getBody()
+            ->__toString();
+
+        Assert::greaterThanEq($response->getStatusCode(), 200);
+        Assert::lessThanEq($response->getStatusCode(), 299);
+
+        $responseData = json_decode($responseBody, true);
+
+        Assert::isMap($responseData);
+        Assert::keyExists($responseData, 'default_branch');
+        Assert::same($defaultBranch->name(), $responseData['default_branch']);
+    }
+}

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Application;
+
+use Laminas\AutomaticReleases\Application\Command\SwitchDefaultBranchToNextMinor;
+use Laminas\AutomaticReleases\Environment\Variables;
+use Laminas\AutomaticReleases\Git\Fetch;
+use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Git\Push;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Git\Value\MergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranch;
+use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
+use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+
+use function mkdir;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class SwitchDefaultBranchToNextMinorTest extends TestCase
+{
+    /** @var Variables&MockObject */
+    private Variables $variables;
+    /** @var LoadCurrentGithubEvent&MockObject */
+    private LoadCurrentGithubEvent $loadEvent;
+    /** @var Fetch&MockObject */
+    private Fetch $fetch;
+    /** @var GetMergeTargetCandidateBranches&MockObject */
+    private GetMergeTargetCandidateBranches $getMergeTargets;
+    /** @var Push&MockObject */
+    private Push $push;
+    /** @var SetDefaultBranch&MockObject */
+    private SetDefaultBranch $setDefaultBranch;
+    private SwitchDefaultBranchToNextMinor $command;
+    private MilestoneClosedEvent $event;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->variables        = $this->createMock(Variables::class);
+        $this->loadEvent        = $this->createMock(LoadCurrentGithubEvent::class);
+        $this->fetch            = $this->createMock(Fetch::class);
+        $this->getMergeTargets  = $this->createMock(GetMergeTargetCandidateBranches::class);
+        $this->push             = $this->createMock(Push::class);
+        $this->setDefaultBranch = $this->createMock(SetDefaultBranch::class);
+
+        $this->command = new SwitchDefaultBranchToNextMinor(
+            $this->variables,
+            $this->loadEvent,
+            $this->fetch,
+            $this->getMergeTargets,
+            $this->push,
+            $this->setDefaultBranch
+        );
+
+        $this->event = MilestoneClosedEvent::fromEventJson(<<<'JSON'
+{
+    "milestone": {
+        "title": "1.2.3",
+        "number": 123
+    },
+    "repository": {
+        "full_name": "foo/bar"
+    },
+    "action": "closed"
+}
+JSON
+        );
+
+        $this->variables->method('githubToken')
+            ->willReturn('github-auth-token');
+    }
+
+    public function testCommandName(): void
+    {
+        self::assertSame('laminas:automatic-releases:switch-default-branch-to-next-minor', $this->command->getName());
+    }
+
+    public function testWillSwitchToExistingNewestDefaultBranch(): void
+    {
+        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+
+        unlink($workspace);
+        mkdir($workspace);
+        mkdir($workspace . '/.git');
+
+        $this->variables->method('githubWorkspacePath')
+            ->willReturn($workspace);
+
+        $this->loadEvent->method('__invoke')
+            ->willReturn($this->event);
+
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+
+        $this->getMergeTargets->method('__invoke')
+            ->with($workspace)
+            ->willReturn(MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.2.x'),
+                BranchName::fromName('1.3.x'),
+                BranchName::fromName('master'),
+            ));
+
+        $this->push->expects(self::never())
+            ->method('__invoke');
+
+        $this->setDefaultBranch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                self::equalTo(RepositoryName::fromFullName('foo/bar')),
+                self::equalTo(BranchName::fromName('1.3.x'))
+            );
+
+        self::assertSame(0, $this->command->run(new ArrayInput([]), new NullOutput()));
+    }
+
+    public function testWillSwitchToNewlyCreatedDefaultBranchWhenNoNewerReleaseBranchExists(): void
+    {
+        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+
+        unlink($workspace);
+        mkdir($workspace);
+        mkdir($workspace . '/.git');
+
+        $this->variables->method('githubWorkspacePath')
+            ->willReturn($workspace);
+
+        $this->loadEvent->method('__invoke')
+            ->willReturn($this->event);
+
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+
+        $this->getMergeTargets->method('__invoke')
+            ->with($workspace)
+            ->willReturn(MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.2.x'),
+                BranchName::fromName('master'),
+            ));
+
+        $this->push->expects(self::once())
+            ->method('__invoke')
+            ->with($workspace, '1.2.x', '1.3.x');
+
+        $this->setDefaultBranch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                self::equalTo(RepositoryName::fromFullName('foo/bar')),
+                self::equalTo(BranchName::fromName('1.3.x'))
+            );
+
+        self::assertSame(0, $this->command->run(new ArrayInput([]), new NullOutput()));
+    }
+
+    public function testWillNotSwitchDefaultBranchIfNoBranchesExist(): void
+    {
+        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+
+        unlink($workspace);
+        mkdir($workspace);
+        mkdir($workspace . '/.git');
+
+        $this->variables->method('githubWorkspacePath')
+            ->willReturn($workspace);
+
+        $this->loadEvent->method('__invoke')
+            ->willReturn($this->event);
+
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+
+        $this->getMergeTargets->method('__invoke')
+            ->with($workspace)
+            ->willReturn(MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('master'),
+            ));
+
+        $this->push->expects(self::never())
+            ->method('__invoke');
+
+        $this->setDefaultBranch->expects(self::never())
+            ->method('__invoke');
+
+        $output = new BufferedOutput();
+
+        self::assertSame(0, $this->command->run(new ArrayInput([]), $output));
+
+        self::assertSame(
+            <<<OUTPUT
+No stable branches found: cannot switch default branch
+
+OUTPUT
+            ,
+            $output->fetch()
+        );
+    }
+}

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -140,12 +140,12 @@ final class BranchNameTest extends TestCase
     /**
      * @dataProvider targetVersionProvider
      */
-    public function testTargetVersion(string $branchName, string $expectedVersion): void
+    public function testTargetMinorReleaseVersion(string $branchName, string $expectedVersion): void
     {
         self::assertEquals(
             SemVerVersion::fromMilestoneName($expectedVersion),
             BranchName::fromName($branchName)
-                ->targetVersion()
+                ->targetMinorReleaseVersion()
         );
     }
 

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -20,7 +20,6 @@ final class BranchNameTest extends TestCase
 
         self::assertSame($inputName, $branch->name());
         self::assertFalse($branch->isReleaseBranch());
-        self::assertFalse($branch->isNextMajor());
     }
 
     /** @return array<int, array<int, string>> */
@@ -45,14 +44,6 @@ final class BranchNameTest extends TestCase
         BranchName::fromName('');
     }
 
-    public function testMasterIsNextMajorRelease(): void
-    {
-        $branch = BranchName::fromName('master');
-
-        self::assertTrue($branch->isNextMajor());
-        self::assertFalse($branch->isReleaseBranch());
-    }
-
     /**
      * @dataProvider releaseBranches
      */
@@ -60,7 +51,6 @@ final class BranchNameTest extends TestCase
     {
         $branch = BranchName::fromName($inputName);
 
-        self::assertFalse($branch->isNextMajor());
         self::assertTrue($branch->isReleaseBranch());
         self::assertSame([$major, $minor], $branch->majorAndMinor());
     }

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -146,4 +146,31 @@ final class BranchNameTest extends TestCase
             ['2.0.0', '1.9', false],
         ];
     }
+
+    /**
+     * @dataProvider targetVersionProvider
+     */
+    public function testTargetVersion(string $branchName, string $expectedVersion): void
+    {
+        self::assertEquals(
+            SemVerVersion::fromMilestoneName($expectedVersion),
+            BranchName::fromName($branchName)
+                ->targetVersion()
+        );
+    }
+
+    /**
+     * @return string[][]
+     *
+     * @psalm-return list<array{0: string, 1: string}>
+     */
+    public function targetVersionProvider(): array
+    {
+        return [
+            ['2.0', '2.0.0'],
+            ['2.0.x', '2.0.0'],
+            ['2.1.x', '2.1.0'],
+            ['1.99.x', '1.99.0'],
+        ];
+    }
 }

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -162,4 +162,165 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             '1.1.1 can\'t have a target branch, since 1.1.x doesn\'t exist, but patches require a release branch'
         );
     }
+
+    public function testWillComputeFutureReleaseBranchFromCurrentRelease(): void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1.x'),
+            BranchName::fromName('1.4.x'),
+            BranchName::fromName('1.2.x'),
+        );
+
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.0.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.1'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.2.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.1'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.5.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.4.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.6.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.5.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('2.1.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('2.0.0'))
+        );
+    }
+
+    public function testWillIgnoreMasterBranchWhenComputingFutureReleaseBranchName(): void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1.x'),
+            BranchName::fromName('1.4.x'),
+            BranchName::fromName('1.2.x'),
+            BranchName::fromName('master'),
+        );
+
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.0.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.1'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.2.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.1'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.5.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.4.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('1.6.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.5.0'))
+        );
+        self::assertEquals(
+            BranchName::fromName('2.1.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('2.0.0'))
+        );
+    }
+
+    public function testContains(): void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1'),
+            BranchName::fromName('1.1.x'),
+            BranchName::fromName('1.2.x'),
+        );
+
+        self::assertTrue($branches->contains(BranchName::fromName('1.1')));
+        self::assertTrue($branches->contains(BranchName::fromName('1.1.x')));
+        self::assertTrue($branches->contains(BranchName::fromName('1.2.x')));
+        self::assertFalse($branches->contains(BranchName::fromName('1.1.1.x')));
+        self::assertFalse($branches->contains(BranchName::fromName('1.1.0')));
+        self::assertFalse($branches->contains(BranchName::fromName('v1.1')));
+        self::assertFalse($branches->contains(BranchName::fromName('v1.1.x')));
+        self::assertFalse($branches->contains(BranchName::fromName('1.2')));
+    }
+
+    public function testNewestReleaseBranch(): void
+    {
+        self::assertEquals(
+            BranchName::fromName('1.2.x'),
+            MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1'),
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.2.x'),
+            )->newestReleaseBranch()
+        );
+
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1'),
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.4.x'),
+                BranchName::fromName('1.2.x'),
+            )->newestReleaseBranch()
+        );
+
+        self::assertEquals(
+            BranchName::fromName('2.0.x'),
+            MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1'),
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.4.x'),
+                BranchName::fromName('1.2.x'),
+                BranchName::fromName('2.0.x'),
+            )->newestReleaseBranch()
+        );
+
+        self::assertEquals(
+            BranchName::fromName('2.0.x'),
+            MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('2.0.x'),
+                BranchName::fromName('master'),
+            )->newestReleaseBranch()
+        );
+
+        self::assertNull(
+            MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('foo'),
+                BranchName::fromName('develop'),
+                BranchName::fromName('master')
+            )->newestReleaseBranch()
+        );
+    }
 }

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -23,16 +23,10 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             BranchName::fromName('1.5')
         );
 
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.99.0'))
-        );
+        self::assertNull($branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.99.0')));
         self::assertNull($branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.99.0')));
 
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0'))
-        );
+        self::assertNull($branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0')));
         self::assertNull($branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0')));
 
         self::assertEquals(
@@ -48,14 +42,8 @@ final class MergeTargetCandidateBranchesTest extends TestCase
             BranchName::fromName('1.5'),
             $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.5.99'))
         );
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.5.99'))
-        );
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.6.0'))
-        );
+        self::assertNull($branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.5.99')));
+        self::assertNull($branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.6.0')));
 
         self::assertEquals(
             BranchName::fromName('1.0'),
@@ -94,44 +82,6 @@ final class MergeTargetCandidateBranchesTest extends TestCase
         self::assertNull(
             $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.2.1')),
             'Cannot merge up: no master branch exists'
-        );
-    }
-
-    public function testWillPickNewMajorReleaseBranchIfNoCurrentReleaseBranchExists(): void
-    {
-        $branches = MergeTargetCandidateBranches::fromAllBranches(
-            BranchName::fromName('1.1'),
-            BranchName::fromName('1.2'),
-            BranchName::fromName('master')
-        );
-
-        self::assertEquals(
-            BranchName::fromName('1.2'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.2.31')),
-            'Next patch release will be tagged from active minor branch'
-        );
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.2.31')),
-            '1.2.x will be merged into master'
-        );
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('1.3.0')),
-            'Next minor release will be tagged from active master branch'
-        );
-        self::assertNull(
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('1.3.0')),
-            '1.3.0 won\'t be merged up, since there\'s no further branches to merge to'
-        );
-        self::assertEquals(
-            BranchName::fromName('master'),
-            $branches->targetBranchFor(SemVerVersion::fromMilestoneName('2.0.0')),
-            'Next major release will be tagged from active master branch'
-        );
-        self::assertNull(
-            $branches->branchToMergeUp(SemVerVersion::fromMilestoneName('2.0.0')),
-            '2.0.0 won\'t be merged up, since there\'s no further branches to merge to'
         );
     }
 

--- a/test/unit/Git/Value/SemVerVersionTest.php
+++ b/test/unit/Git/Value/SemVerVersionTest.php
@@ -118,4 +118,44 @@ final class SemVerVersionTest extends TestCase
             ['0.9.0', true],
         ];
     }
+
+    /**
+     * @dataProvider lessThanEqualProvider
+     */
+    public function testLessThanEqual(string $a, string $b, bool $expected): void
+    {
+        self::assertEquals(
+            $expected,
+            SemVerVersion::fromMilestoneName($a)
+                ->lessThanEqual(SemVerVersion::fromMilestoneName($b))
+        );
+    }
+
+    /**
+     * @return string[][]|bool[][]
+     *
+     * @psalm-return non-empty-list<array{string, string, bool}>
+     */
+    public function lessThanEqualProvider(): array
+    {
+        return [
+            ['0.0.1', '0.0.1', true],
+            ['0.0.2', '0.0.1', false],
+            ['0.0.1', '0.0.2', true],
+            ['0.0.1', '0.1.0', true],
+            ['0.1.0', '0.0.1', false],
+            ['1.0.0', '0.0.1', false],
+            ['0.0.1', '1.0.0', true],
+            ['1.0.0', '1.0.0', true],
+            ['1.0.1', '1.0.0', false],
+            ['1.0.0', '1.0.1', true],
+            ['0.1.0', '0.1.0', true],
+            ['0.1.1', '0.1.0', false],
+            ['0.1.0', '0.1.1', true],
+            ['0.1.0', '0.1.0', true],
+            ['0.1.1', '0.1.0', false],
+            ['2.0.0', '1.0.0', false],
+            ['1.0.0', '2.0.0', true],
+        ];
+    }
 }

--- a/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
+++ b/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Github\Api\V3;
+
+use InvalidArgumentException;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranchThroughApiCall;
+use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Webmozart\Assert\Assert;
+
+use function uniqid;
+
+/** @covers \Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranchThroughApiCall */
+final class SetDefaultBranchThroughApiCallTest extends TestCase
+{
+    /** @var ClientInterface&MockObject */
+    private $httpClient;
+    /** @var RequestFactoryInterface&MockObject */
+    private $messageFactory;
+    /** @psalm-var non-empty-string */
+    private string $apiToken;
+    private SetDefaultBranchThroughApiCall $createRelease;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->httpClient     = $this->createMock(ClientInterface::class);
+        $this->messageFactory = $this->createMock(RequestFactoryInterface::class);
+        $apiToken             = uniqid('apiToken', true);
+
+        Assert::notEmpty($apiToken);
+
+        $this->apiToken      = $apiToken;
+        $this->createRelease = new SetDefaultBranchThroughApiCall(
+            $this->messageFactory,
+            $this->httpClient,
+            $this->apiToken
+        );
+    }
+
+    public function testSuccessfulRequest(): void
+    {
+        $this
+            ->messageFactory
+            ->expects(self::any())
+            ->method('createRequest')
+            ->with('PATCH', 'https://api.github.com/repos/foo/bar')
+            ->willReturn(new Request('https://the-domain.com/the-path'));
+
+        $validResponse = new Response();
+
+        $validResponse->getBody()
+            ->write('{"default_branch": "foo-bar-baz"}');
+
+        $this
+            ->httpClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->with(self::callback(function (RequestInterface $request): bool {
+                self::assertSame(
+                    [
+                        'Host'          => ['the-domain.com'],
+                        'Content-Type'  => ['application/json'],
+                        'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
+                        'Authorization' => ['bearer ' . $this->apiToken],
+                    ],
+                    $request->getHeaders()
+                );
+
+                self::assertJsonStringEqualsJsonString(
+                    '{"default_branch": "foo-bar-baz"}',
+                    $request->getBody()
+                        ->__toString()
+                );
+
+                return true;
+            }))
+            ->willReturn($validResponse);
+
+        $this->createRelease->__invoke(
+            RepositoryName::fromFullName('foo/bar'),
+            BranchName::fromName('foo-bar-baz')
+        );
+    }
+
+    public function testRequestFailedToSwitchBranch(): void
+    {
+        $this
+            ->messageFactory
+            ->expects(self::any())
+            ->method('createRequest')
+            ->with('PATCH', 'https://api.github.com/repos/foo/bar')
+            ->willReturn(new Request('https://the-domain.com/the-path'));
+
+        $validResponse = new Response();
+
+        $validResponse->getBody()
+            ->write('{"default_branch": "not-what-we-expected"}');
+
+        $this
+            ->httpClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->with(self::callback(function (RequestInterface $request): bool {
+                self::assertSame(
+                    [
+                        'Host'          => ['the-domain.com'],
+                        'Content-Type'  => ['application/json'],
+                        'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
+                        'Authorization' => ['bearer ' . $this->apiToken],
+                    ],
+                    $request->getHeaders()
+                );
+
+                self::assertJsonStringEqualsJsonString(
+                    '{"default_branch": "foo-bar-baz"}',
+                    $request->getBody()
+                        ->__toString()
+                );
+
+                return true;
+            }))
+            ->willReturn($validResponse);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not-what-we-expected');
+
+        $this->createRelease->__invoke(
+            RepositoryName::fromFullName('foo/bar'),
+            BranchName::fromName('foo-bar-baz')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #11 by providing default logic for switching to a new default branch at
every release. Specifically:

 * when a newer release target branch exists, use that (i.e. release `1.2.3` => existing branch `1.5.x`,
   switch to `1.5.x`)
 * when a newer release branch does not exist, create it (i.e. release `1.2.3` => existing branch `1.2.x`,
   create `1.3.x` from `1.2.x`, use `1.3.x`)
 * when no release branches exist, skip entire execution

TODOs:

 * [x] try this out in a sandbox repository
 * [x] better documentation? (new `feature/` files)
 * [x] update examples
 * [x] get rid of special handling for `master`, which is not interesting to us anymore
 * [x] document token requirements

Note: it would be good to get this into `1.0.0`, since it breaks BC by changing semantics around the `master` branch naming.