### PR TITLE
Corrected released action format - must be same as tags

### DIFF
--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -17,7 +17,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "laminas/automatic-releases@v1.0.0"
+        uses: "laminas/automatic-releases@1.0.1"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -27,7 +27,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@v1.0.0"
+        uses: "laminas/automatic-releases@1.0.1"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
@@ -37,7 +37,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create and/or Switch to new Release Branch"
-        uses: "laminas/automatic-releases@v1.0.0"
+        uses: "laminas/automatic-releases@1.0.1"
         with:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:


### PR DESCRIPTION
As noticed while testing in https://github.com/Ocramius/just-trying-automated-releases/pull/16,
the action version must correspond exactly to the tag name, in order to be referenced by third
parties.
