### PR TITLE
Use US spelling for organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git commit -m "Added release automation"
 ```
 
 Then add following [secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
-to your project or organisation:
+to your project or organization:
 
  * `GIT_AUTHOR_NAME` - full name of the author of your releases: can be the name of a bot account.
  * `GIT_AUTHOR_EMAIL` - email address of the author of your releases: can be an email address of a bot account.
@@ -27,7 +27,7 @@ to your project or organisation:
    please use a dedicated GPG subkey for this purpose. Unsigned releases are not supported, and won't be supported.
  * `ORGANIZATION_ADMIN_TOKEN` - if you use the file from [`examples/.github/workflows/release-on-milestone-closed.yml`](examples/.github/workflows/release-on-milestone-closed.yml),
    then you have to provide a `ORGANIZATION_ADMIN_TOKEN`, which is a github token with administrative rights over
-   your organisation (issued by a user that has administrative rights over your project).
+   your organization (issued by a user that has administrative rights over your project).
    This is required for the `laminas:automatic-releases:switch-default-branch-to-next-minor`
    command, because [changing default branch of a repository currently requires administrative token rights](https://developer.github.com/v3/repos/#update-a-repository).
    You can generate a token from your [personal access tokens page](https://github.com/settings/tokens/new).


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

I know that organisation is correct, but using the US spelling matches the `ORGANIZATION_ADMIN_TOKEN` secret.