### PR TITLE
Update example workflow to reference `v1` as release version

### DIFF
--- a/.github/workflows/update-major-release.yml
+++ b/.github/workflows/update-major-release.yml
@@ -1,0 +1,20 @@
+# https://github.com/marketplace/actions/actions-tagger
+
+name: "Keep major release version up-to-date"
+
+on:
+  release:
+    types:
+      - published
+      - edited
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        with:
+          publish_latest_tag: false
+          prefer_branch_releases: false
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN}}

--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -17,7 +17,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "laminas/automatic-releases@1.0.1"
+        uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -27,7 +27,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@1.0.1"
+        uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
@@ -37,7 +37,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create and/or Switch to new Release Branch"
-        uses: "laminas/automatic-releases@1.0.1"
+        uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:


### PR DESCRIPTION
When a new release is published, if it is the most recent version in the current major version series, we should point a tag `v{MAJOR}` at the new release.

This patch:

- Updates the example workflow to point to the `v1` release.
- Adds a github workflow, `update-major-release.yml`, that makes use of the action "actions-tagger", which compares the current release against other releases in the current major version, and repoints the `v{MAJOR}` tag if so.

Fixes #34