### PR TITLE
When a new release is made, bump the `CHANGELOG` version in the next release branch and the originating release branch

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -45,3 +45,13 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Bump Changelog Version On Originating Release Branch"
+        uses: "./"
+        with:
+          command-name: "laminas:automatic-releases:bump-changelog"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.2.0 - TBD
+
+### Added
+
+- [#40](https://github.com/laminas/automatic-releases/pull/40) adds a new command, laminas:automatic-releases:bump-changelog. When a `CHANGELOG.md` file is present in the repository, it will add an entry in the file for the next patch-level release to the target branch of the closed milestone. The patch also adds the command to the end of the suggested workflow configuration.
+
+### Changed
+
+- [#40](https://github.com/laminas/automatic-releases/pull/40) updates the laminas:automatic-releases:switch-default-branch-to-next-minor command such that if a `CHANGELOG.md` file is present in the repository, and a new minor release branch is created, it adds an entry to the file for the next minor release.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.1.0 - 2020-08-06
 
 ### Added

--- a/bin/console.php
+++ b/bin/console.php
@@ -8,6 +8,7 @@ namespace Laminas\AutomaticReleases\WebApplication;
 use ErrorException;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Laminas\AutomaticReleases\Application\Command\BumpChangelogForReleaseBranch;
 use Laminas\AutomaticReleases\Application\Command\CreateMergeUpPullRequest;
 use Laminas\AutomaticReleases\Application\Command\ReleaseCommand;
 use Laminas\AutomaticReleases\Application\Command\SwitchDefaultBranchToNextMinor;
@@ -133,6 +134,13 @@ use const STDERR;
                 $httpClient,
                 $githubToken
             ),
+            $bumpChangelogVersion
+        ),
+        new BumpChangelogForReleaseBranch(
+            $variables,
+            $loadEvent,
+            $fetch,
+            $getCandidateBranches,
             $bumpChangelogVersion
         ),
     ]);

--- a/bin/console.php
+++ b/bin/console.php
@@ -11,8 +11,10 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Laminas\AutomaticReleases\Application\Command\CreateMergeUpPullRequest;
 use Laminas\AutomaticReleases\Application\Command\ReleaseCommand;
 use Laminas\AutomaticReleases\Application\Command\SwitchDefaultBranchToNextMinor;
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersionViaKeepAChangelog;
 use Laminas\AutomaticReleases\Changelog\CommitReleaseChangelogViaKeepAChangelog;
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
+use Laminas\AutomaticReleases\Git\CheckoutBranchViaConsole;
 use Laminas\AutomaticReleases\Git\CommitFileViaConsole;
 use Laminas\AutomaticReleases\Git\CreateTagViaConsole;
 use Laminas\AutomaticReleases\Git\FetchAndSetCurrentUserByReplacingCurrentOriginRemote;
@@ -66,6 +68,7 @@ use const STDERR;
         $httpClient,
         $githubToken
     ));
+    $checkoutBranch       = new CheckoutBranchViaConsole();
     $commit               = new CommitFileViaConsole();
     $push                 = new PushViaConsole();
     $commitChangelog      = new CommitReleaseChangelogViaKeepAChangelog(new SystemClock(), $commit, $push, $logger);
@@ -81,6 +84,12 @@ use const STDERR;
         $makeRequests,
         $httpClient,
         $githubToken
+    );
+    $bumpChangelogVersion = new BumpAndCommitChangelogVersionViaKeepAChangelog(
+        $checkoutBranch,
+        $commit,
+        $push,
+        $logger
     );
 
     /** @psalm-suppress DeprecatedClass */
@@ -123,7 +132,8 @@ use const STDERR;
                 $makeRequests,
                 $httpClient,
                 $githubToken
-            )
+            ),
+            $bumpChangelogVersion
         ),
     ]);
 

--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -45,3 +45,13 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Bump Changelog Version On Originating Release Branch"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:bump-changelog"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/src/Application/Command/BumpChangelogForReleaseBranch.php
+++ b/src/Application/Command/BumpChangelogForReleaseBranch.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Application\Command;
+
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersion;
+use Laminas\AutomaticReleases\Environment\Variables;
+use Laminas\AutomaticReleases\Git\Fetch;
+use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+use function sprintf;
+
+final class BumpChangelogForReleaseBranch extends Command
+{
+    private Variables $environment;
+    private LoadCurrentGithubEvent $loadEvent;
+    private Fetch $fetch;
+    private GetMergeTargetCandidateBranches $getMergeTargets;
+    private BumpAndCommitChangelogVersion $bumpChangelogVersion;
+
+    public function __construct(
+        Variables $environment,
+        LoadCurrentGithubEvent $loadEvent,
+        Fetch $fetch,
+        GetMergeTargetCandidateBranches $getMergeTargets,
+        BumpAndCommitChangelogVersion $bumpChangelogVersion
+    ) {
+        parent::__construct('laminas:automatic-releases:bump-changelog');
+
+        $this->environment          = $environment;
+        $this->loadEvent            = $loadEvent;
+        $this->fetch                = $fetch;
+        $this->getMergeTargets      = $getMergeTargets;
+        $this->bumpChangelogVersion = $bumpChangelogVersion;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $milestoneClosedEvent = ($this->loadEvent)();
+        $repositoryName       = $milestoneClosedEvent->repository();
+        $repositoryCloneUri   = $repositoryName->uriWithTokenAuthentication($this->environment->githubToken());
+        $repositoryPath       = $this->environment->githubWorkspacePath();
+
+        Assert::directory($repositoryPath . '/.git');
+
+        ($this->fetch)($repositoryCloneUri, $repositoryPath);
+
+        $mergeCandidates = ($this->getMergeTargets)($repositoryPath);
+        $releaseVersion  = $milestoneClosedEvent->version();
+        $releaseBranch   = $mergeCandidates->targetBranchFor($releaseVersion);
+
+        Assert::notNull(
+            $releaseBranch,
+            sprintf('No valid release branch found for version %s', $releaseVersion->fullReleaseName())
+        );
+
+        ($this->bumpChangelogVersion)(
+            BumpAndCommitChangelogVersion::BUMP_PATCH,
+            $repositoryPath,
+            $releaseVersion,
+            $releaseBranch
+        );
+
+        return 0;
+    }
+}

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Application\Command;
 
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersion;
 use Laminas\AutomaticReleases\Environment\Variables;
 use Laminas\AutomaticReleases\Git\Fetch;
 use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
@@ -23,6 +24,7 @@ final class SwitchDefaultBranchToNextMinor extends Command
     private GetMergeTargetCandidateBranches $getMergeCandidates;
     private Push $push;
     private SetDefaultBranch $switchDefaultBranch;
+    private BumpAndCommitChangelogVersion $bumpChangelogVersion;
 
     public function __construct(
         Variables $variables,
@@ -30,16 +32,18 @@ final class SwitchDefaultBranchToNextMinor extends Command
         Fetch $fetch,
         GetMergeTargetCandidateBranches $getMergeCandidates,
         Push $push,
-        SetDefaultBranch $switchDefaultBranch
+        SetDefaultBranch $switchDefaultBranch,
+        BumpAndCommitChangelogVersion $bumpChangelogVersion
     ) {
         parent::__construct('laminas:automatic-releases:switch-default-branch-to-next-minor');
 
-        $this->variables           = $variables;
-        $this->loadGithubEvent     = $loadGithubEvent;
-        $this->fetch               = $fetch;
-        $this->getMergeCandidates  = $getMergeCandidates;
-        $this->push                = $push;
-        $this->switchDefaultBranch = $switchDefaultBranch;
+        $this->variables            = $variables;
+        $this->loadGithubEvent      = $loadGithubEvent;
+        $this->fetch                = $fetch;
+        $this->getMergeCandidates   = $getMergeCandidates;
+        $this->push                 = $push;
+        $this->switchDefaultBranch  = $switchDefaultBranch;
+        $this->bumpChangelogVersion = $bumpChangelogVersion;
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -72,6 +76,12 @@ final class SwitchDefaultBranchToNextMinor extends Command
                 $repositoryPath,
                 $newestBranch->name(),
                 $nextDefaultBranch->name()
+            );
+            ($this->bumpChangelogVersion)(
+                BumpAndCommitChangelogVersion::BUMP_MINOR,
+                $repositoryPath,
+                $releaseVersion,
+                $newestBranch
             );
         }
 

--- a/src/Changelog/BumpAndCommitChangelogVersion.php
+++ b/src/Changelog/BumpAndCommitChangelogVersion.php
@@ -12,14 +12,9 @@ interface BumpAndCommitChangelogVersion
     public const BUMP_MINOR = 'bumpMinorVersion';
     public const BUMP_PATCH = 'bumpPatchVersion';
 
-    public const KNOWN_BUMP_TYPES = [
-        self::BUMP_MINOR,
-        self::BUMP_PATCH,
-    ];
-
     /**
-     * @psalm-param value-of<self::KNOWN_BUMP_TYPES> $bumpType
-     * @psalm-param non-empty-string                 $repositoryDirectory
+     * @psalm-param self::BUMP_*     $bumpType
+     * @psalm-param non-empty-string $repositoryDirectory
      */
     public function __invoke(
         string $bumpType,

--- a/src/Changelog/BumpAndCommitChangelogVersion.php
+++ b/src/Changelog/BumpAndCommitChangelogVersion.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Changelog;
+
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+
+interface BumpAndCommitChangelogVersion
+{
+    public const BUMP_MINOR = 'bumpMinorVersion';
+    public const BUMP_PATCH = 'bumpPatchVersion';
+
+    public const KNOWN_BUMP_TYPES = [
+        self::BUMP_MINOR,
+        self::BUMP_PATCH,
+    ];
+
+    /**
+     * @psalm-param value-of<self::KNOWN_BUMP_TYPES> $bumpType
+     * @psalm-param non-empty-string                 $repositoryDirectory
+     */
+    public function __invoke(
+        string $bumpType,
+        string $repositoryDirectory,
+        SemVerVersion $version,
+        BranchName $sourceBranch
+    ): void;
+}

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Changelog;
+
+use Laminas\AutomaticReleases\Git\CheckoutBranch;
+use Laminas\AutomaticReleases\Git\CommitFile;
+use Laminas\AutomaticReleases\Git\Push;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Phly\KeepAChangelog\Bump\ChangelogBump;
+use Psr\Log\LoggerInterface;
+use Webmozart\Assert\Assert;
+
+use function file_exists;
+use function sprintf;
+
+class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitChangelogVersion
+{
+    private const CHANGELOG_FILE = 'CHANGELOG.md';
+
+    private const COMMIT_TEMPLATE = <<< 'COMMIT'
+        Bumps changelog version to %s
+
+        Updates the %s file to add a changelog entry for a new %s version.
+        COMMIT;
+
+    private CheckoutBranch $checkoutBranch;
+    private CommitFile $commitFile;
+    private Push $push;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        CheckoutBranch $checkoutBranch,
+        CommitFile $commitFile,
+        Push $push,
+        LoggerInterface $logger
+    ) {
+        $this->checkoutBranch = $checkoutBranch;
+        $this->commitFile     = $commitFile;
+        $this->push           = $push;
+        $this->logger         = $logger;
+    }
+
+    public function __invoke(
+        string $bumpType,
+        string $repositoryDirectory,
+        SemVerVersion $version,
+        BranchName $sourceBranch
+    ): void {
+        ($this->checkoutBranch)($repositoryDirectory, $sourceBranch->name());
+
+        $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
+        if (! file_exists($changelogFile)) {
+            // No changelog
+            $this->logger->info('BumpAndCommitChangelog: No CHANGELOG.md file detected');
+
+            return;
+        }
+
+        $versionString = $version->fullReleaseName();
+        $bumper        = new ChangelogBump($changelogFile);
+        $newVersion    = $bumper->$bumpType($versionString);
+
+        Assert::stringNotEmpty($newVersion);
+        $bumper->updateChangelog($newVersion);
+
+        ($this->commitFile)(
+            $repositoryDirectory,
+            $sourceBranch,
+            self::CHANGELOG_FILE,
+            sprintf(self::COMMIT_TEMPLATE, $newVersion, self::CHANGELOG_FILE, $newVersion)
+        );
+
+        ($this->push)($repositoryDirectory, $sourceBranch->name());
+
+        $this->logger->info(sprintf(
+            'BumpAndCommitChangelog: bumped %s to version %s in branch %s',
+            self::CHANGELOG_FILE,
+            $newVersion,
+            $sourceBranch->name()
+        ));
+    }
+}

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -49,7 +49,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
         SemVerVersion $version,
         BranchName $sourceBranch
     ): void {
-        ($this->checkoutBranch)($repositoryDirectory, $sourceBranch->name());
+        ($this->checkoutBranch)($repositoryDirectory, $sourceBranch);
 
         $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
         if (! file_exists($changelogFile)) {

--- a/src/Git/CheckoutBranch.php
+++ b/src/Git/CheckoutBranch.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Git;
+
+interface CheckoutBranch
+{
+    /**
+     * @psalm-param non-empty-string $repositoryDirectory
+     * @psalm-param non-empty-string $branchName
+     */
+    public function __invoke(
+        string $repositoryDirectory,
+        string $branchName
+    ): void;
+}

--- a/src/Git/CheckoutBranch.php
+++ b/src/Git/CheckoutBranch.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git;
 
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+
 interface CheckoutBranch
 {
     /**
      * @psalm-param non-empty-string $repositoryDirectory
-     * @psalm-param non-empty-string $branchName
      */
     public function __invoke(
         string $repositoryDirectory,
-        string $branchName
+        BranchName $branchName
     ): void;
 }

--- a/src/Git/CheckoutBranchViaConsole.php
+++ b/src/Git/CheckoutBranchViaConsole.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git;
 
+use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Symfony\Component\Process\Process;
 
 class CheckoutBranchViaConsole implements CheckoutBranch
 {
     public function __invoke(
         string $repositoryDirectory,
-        string $branchName
+        BranchName $branchName
     ): void {
-        (new Process(['git', 'checkout', $branchName], $repositoryDirectory))
+        (new Process(['git', 'checkout', $branchName->name()], $repositoryDirectory))
             ->mustRun();
     }
 }

--- a/src/Git/CheckoutBranchViaConsole.php
+++ b/src/Git/CheckoutBranchViaConsole.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Git;
+
+use Symfony\Component\Process\Process;
+
+class CheckoutBranchViaConsole implements CheckoutBranch
+{
+    public function __invoke(
+        string $repositoryDirectory,
+        string $branchName
+    ): void {
+        (new Process(['git', 'checkout', $branchName], $repositoryDirectory))
+            ->mustRun();
+    }
+}

--- a/src/Git/CheckoutBranchViaConsole.php
+++ b/src/Git/CheckoutBranchViaConsole.php
@@ -13,7 +13,7 @@ class CheckoutBranchViaConsole implements CheckoutBranch
         string $repositoryDirectory,
         BranchName $branchName
     ): void {
-        (new Process(['git', 'checkout', $branchName->name()], $repositoryDirectory))
+        (new Process(['git', 'switch', $branchName->name()], $repositoryDirectory))
             ->mustRun();
     }
 }

--- a/test/unit/Application/BumpChangelogForReleaseBranchTest.php
+++ b/test/unit/Application/BumpChangelogForReleaseBranchTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Application;
+
+use Laminas\AutomaticReleases\Application\Command\BumpChangelogForReleaseBranch;
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersion;
+use Laminas\AutomaticReleases\Environment\Variables;
+use Laminas\AutomaticReleases\Git\Fetch;
+use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Git\Value\MergeTargetCandidateBranches;
+use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+use function mkdir;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class BumpChangelogForReleaseBranchTest extends TestCase
+{
+    /** @var Variables&MockObject */
+    private $environment;
+    /** @var LoadCurrentGithubEvent&MockObject */
+    private $loadEvent;
+    /** @var Fetch&MockObject */
+    private $fetch;
+    /** @var GetMergeTargetCandidateBranches&MockObject */
+    private $getMergeTargets;
+    /** @var BumpAndCommitChangelogVersion&MockObject */
+    private $bumpChangelogVersion;
+    private MilestoneClosedEvent $event;
+    private BumpChangelogForReleaseBranch $command;
+
+    protected function setUp(): void
+    {
+        $this->environment          = $this->createMock(Variables::class);
+        $this->loadEvent            = $this->createMock(LoadCurrentGithubEvent::class);
+        $this->fetch                = $this->createMock(Fetch::class);
+        $this->getMergeTargets      = $this->createMock(GetMergeTargetCandidateBranches::class);
+        $this->bumpChangelogVersion = $this->createMock(BumpAndCommitChangelogVersion::class);
+
+        $this->command = new BumpChangelogForReleaseBranch(
+            $this->environment,
+            $this->loadEvent,
+            $this->fetch,
+            $this->getMergeTargets,
+            $this->bumpChangelogVersion
+        );
+
+        $this->event = MilestoneClosedEvent::fromEventJson(<<< 'JSON'
+            {
+                "milestone": {
+                    "title": "1.2.3",
+                    "number": 123
+                },
+                "repository": {
+                    "full_name": "foo/bar"
+                },
+                "action": "closed"
+            }
+            JSON);
+    }
+
+    public function testWillBumpChangelogVersion(): void
+    {
+        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+
+        unlink($workspace);
+        mkdir($workspace);
+        mkdir($workspace . '/.git');
+
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('1.1.x'),
+            BranchName::fromName('1.2.x'),
+            BranchName::fromName('1.3.x')
+        );
+
+        $this->loadEvent->method('__invoke')->willReturn($this->event);
+        $this->environment->method('githubToken')->willReturn('github-auth-token');
+        $this->environment->method('githubWorkspacePath')->willReturn($workspace);
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
+        $this->getMergeTargets->expects(self::once())
+            ->method('__invoke')
+            ->with($workspace)
+            ->willReturn($branches);
+
+        $this->bumpChangelogVersion->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                BumpAndCommitChangelogVersion::BUMP_PATCH,
+                $workspace,
+                self::equalTo(SemVerVersion::fromMilestoneName('1.2.3')),
+                self::equalTo(BranchName::fromName('1.2.x'))
+            );
+
+        self::assertSame(0, $this->command->run(new ArrayInput([]), new NullOutput()));
+    }
+}

--- a/test/unit/Application/ReleaseCommandTest.php
+++ b/test/unit/Application/ReleaseCommandTest.php
@@ -86,7 +86,7 @@ final class ReleaseCommandTest extends TestCase
             $this->createReleaseText,
             $this->createTag,
             $this->push,
-            $this->createRelease
+            $this->createRelease,
         );
 
         $this->event = MilestoneClosedEvent::fromEventJson(<<<'JSON'

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Changelog;
+
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersion;
+use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersionViaKeepAChangelog;
+use Laminas\AutomaticReleases\Git\CheckoutBranch;
+use Laminas\AutomaticReleases\Git\CommitFile;
+use Laminas\AutomaticReleases\Git\Push;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
+
+use function dirname;
+use function file_get_contents;
+use function file_put_contents;
+use function Safe\tempnam;
+use function sprintf;
+use function sys_get_temp_dir;
+use function unlink;
+
+class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
+{
+    /** @var CheckoutBranch&MockObject */
+    private $checkoutBranch;
+    /** @var CommitFile&MockObject */
+    private $commitFile;
+    /** @var Push&MockObject */
+    private $push;
+    /** @var LoggerInterface&MockObject */
+    private $logger;
+    private BumpAndCommitChangelogVersionViaKeepAChangelog $bumpAndCommitChangelog;
+
+    protected function setUp(): void
+    {
+        $this->checkoutBranch         = $this->createMock(CheckoutBranch::class);
+        $this->commitFile             = $this->createMock(CommitFile::class);
+        $this->push                   = $this->createMock(Push::class);
+        $this->logger                 = $this->createMock(LoggerInterface::class);
+        $this->bumpAndCommitChangelog = new BumpAndCommitChangelogVersionViaKeepAChangelog(
+            $this->checkoutBranch,
+            $this->commitFile,
+            $this->push,
+            $this->logger
+        );
+    }
+
+    public function testReturnsEarlyWhenNoChangelogFilePresent(): void
+    {
+        $repoDir      = __DIR__;
+        $branchName   = '1.0.x';
+        $sourceBranch = BranchName::fromName('1.0.x');
+        $version      = SemVerVersion::fromMilestoneName('1.0.1');
+
+        $this->checkoutBranch
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->equalTo($repoDir),
+                $this->equalTo($branchName)
+            );
+
+        $this->logger
+            ->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains('No CHANGELOG.md file detected'));
+
+        $this->assertNull(
+            ($this->bumpAndCommitChangelog)(
+                BumpAndCommitChangelogVersion::BUMP_PATCH,
+                $repoDir,
+                $version,
+                $sourceBranch
+            )
+        );
+    }
+
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification
+
+    /**
+     * @return iterable<
+     *     string,
+     *     array{
+     *         0: value-of<BumpAndCommitChangelogVersion::KNOWN_BUMP_TYPES>,
+     *         1: non-empty-string,
+     *         2: non-empty-string
+     *     }
+     * >
+     */
+    public function bumpTypes(): iterable
+    {
+        // phpcs:enable
+        yield 'bump-patch' => [BumpAndCommitChangelogVersion::BUMP_PATCH, '1.0.x', '1.0.2'];
+        yield 'bump-minor' => [BumpAndCommitChangelogVersion::BUMP_MINOR, '1.1.x', '1.1.0'];
+    }
+
+    /**
+     * @param value-of<BumpAndCommitChangelogVersion::KNOWN_BUMP_TYPES> $bumpType
+     * @param non-empty-string                                          $branchName
+     * @param non-empty-string                                          $expectedVersion
+     *
+     * @dataProvider bumpTypes
+     */
+    public function testAddsNewReleaseVersionUsingBumpTypeToChangelogFileAndCommitsAndPushes(
+        string $bumpType,
+        string $branchName,
+        string $expectedVersion
+    ): void {
+        $changelogFile = $this->createMockChangelog();
+        $repoDir       = dirname($changelogFile);
+        $sourceBranch  = BranchName::fromName($branchName);
+        $version       = SemVerVersion::fromMilestoneName('1.0.1');
+
+        Assert::stringNotEmpty($repoDir);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains(sprintf(
+                'Bumped CHANGELOG.md to version %s in branch %s',
+                $expectedVersion,
+                $branchName
+            )));
+
+        $this->checkoutBranch
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->equalTo($repoDir),
+                $this->equalTo($branchName)
+            );
+
+        $this->commitFile
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+                $this->equalTo($repoDir),
+                $sourceBranch,
+                'CHANGELOG.md',
+                $this->stringContains(sprintf(
+                    'Bumps changelog version to %s',
+                    $expectedVersion
+                ))
+            );
+
+        $this->push
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with(
+            );
+
+        $this->assertNull(
+            ($this->bumpAndCommitChangelog)(
+                $bumpType,
+                $repoDir,
+                $version,
+                $sourceBranch
+            )
+        );
+
+        $changelogContents = file_get_contents($changelogFile);
+        $this->assertMatchesRegularExpression(
+            '/^## ' . $expectedVersion . ' - TBD$/m',
+            $changelogContents,
+            sprintf(
+                'Could not locate entry for new version %s in file %s',
+                $expectedVersion,
+                $changelogFile
+            )
+        );
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    private function createMockChangelog(): string
+    {
+        $repo = tempnam(sys_get_temp_dir(), 'BumpAndCommitChangelogVersion');
+        Assert::notEmpty($repo);
+        unlink($repo);
+
+        (new Process(['mkdir', '-p', $repo]))->mustRun();
+
+        $changelogFile = sprintf('%s/CHANGELOG.md', $repo);
+        Assert::stringNotEmpty($changelogFile);
+
+        file_put_contents($changelogFile, self::CHANGELOG_STUB);
+
+        return $changelogFile;
+    }
+
+    private const CHANGELOG_STUB = <<< 'CHANGELOG'
+        # Changelog
+        
+        All notable changes to this project will be documented in this file, in reverse chronological order by release.
+        
+        ## 1.0.1 - 2020-08-06
+        
+        ### Added
+        
+        - Nothing.
+        
+        ### Changed
+        
+        - Nothing.
+        
+        ### Deprecated
+        
+        - Nothing.
+        
+        ### Removed
+        
+        - Nothing.
+        
+        ### Fixed
+        
+        - Fixed a bug.
+        CHANGELOG;
+}

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -87,7 +87,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
      * @return iterable<
      *     string,
      *     array{
-     *         0: value-of<BumpAndCommitChangelogVersion::KNOWN_BUMP_TYPES>,
+     *         0: BumpAndCommitChangelogVersion::BUMP_*,
      *         1: non-empty-string,
      *         2: non-empty-string
      *     }
@@ -101,9 +101,9 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
     }
 
     /**
-     * @param value-of<BumpAndCommitChangelogVersion::KNOWN_BUMP_TYPES> $bumpType
-     * @param non-empty-string                                          $branchName
-     * @param non-empty-string                                          $expectedVersion
+     * @param BumpAndCommitChangelogVersion::BUMP_* $bumpType
+     * @param non-empty-string                      $branchName
+     * @param non-empty-string                      $expectedVersion
      *
      * @dataProvider bumpTypes
      */

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -54,7 +54,6 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
     public function testReturnsEarlyWhenNoChangelogFilePresent(): void
     {
         $repoDir      = __DIR__;
-        $branchName   = '1.0.x';
         $sourceBranch = BranchName::fromName('1.0.x');
         $version      = SemVerVersion::fromMilestoneName('1.0.1');
 
@@ -63,7 +62,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->equalTo($repoDir),
-                $this->equalTo($branchName)
+                $sourceBranch
             );
 
         $this->logger
@@ -133,7 +132,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
             ->method('__invoke')
             ->with(
                 $this->equalTo($repoDir),
-                $this->equalTo($branchName)
+                $sourceBranch
             );
 
         $this->commitFile

--- a/test/unit/Git/CheckoutBranchViaConsoleTest.php
+++ b/test/unit/Git/CheckoutBranchViaConsoleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Test\Unit\Git;
 
 use Laminas\AutomaticReleases\Git\CheckoutBranchViaConsole;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
@@ -60,7 +61,7 @@ class CheckoutBranchViaConsoleTest extends TestCase
     public function testSwitchesToSpecifiedBranch(): void
     {
         $checkoutBranch = new CheckoutBranchViaConsole();
-        $checkoutBranch($this->checkout, '1.0.x');
+        $checkoutBranch($this->checkout, BranchName::fromName('1.0.x'));
         $this->assertBranch('1.0.x', 'Failed to checkout 1.0.x branch');
     }
 

--- a/test/unit/Git/CheckoutBranchViaConsoleTest.php
+++ b/test/unit/Git/CheckoutBranchViaConsoleTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Git;
+
+use Laminas\AutomaticReleases\Git\CheckoutBranchViaConsole;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
+
+use function mkdir;
+use function Safe\tempnam;
+use function sys_get_temp_dir;
+use function trim;
+use function unlink;
+
+class CheckoutBranchViaConsoleTest extends TestCase
+{
+    /** @psalm-var non-empty-string */
+    private string $checkout;
+
+    public function setUp(): void
+    {
+        $checkout = tempnam(sys_get_temp_dir(), 'CommitFileViaConsoleTestCheckout');
+        Assert::notEmpty($checkout);
+
+        $this->checkout = $checkout;
+        unlink($this->checkout);
+        mkdir($this->checkout);
+
+        (new Process(['git', 'init'], $this->checkout))
+            ->mustRun();
+        (new Process(['git', 'config', 'user.email', 'me@example.com'], $this->checkout))
+            ->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Just Me'], $this->checkout))
+            ->mustRun();
+
+        (new Process(
+            ['git', 'symbolic-ref', 'HEAD', 'refs/heads/1.0.x'],
+            $this->checkout
+        ))
+            ->mustRun();
+
+        (new Process(['touch', 'README.md'], $this->checkout))
+            ->mustRun();
+
+        (new Process(['git', 'add', 'README.md'], $this->checkout))
+            ->mustRun();
+
+        (new Process(['git', 'commit', '-m', 'Initial import'], $this->checkout))
+            ->mustRun();
+
+        (new Process(['git', 'switch', '-c', '1.1.x'], $this->checkout))
+            ->mustRun();
+
+        $this->assertBranch('1.1.x', 'Setup failed to set initial branch to 1.1.x');
+    }
+
+    public function testSwitchesToSpecifiedBranch(): void
+    {
+        $checkoutBranch = new CheckoutBranchViaConsole();
+        $checkoutBranch($this->checkout, '1.0.x');
+        $this->assertBranch('1.0.x', 'Failed to checkout 1.0.x branch');
+    }
+
+    /** @param non-empty-string $branchName */
+    private function assertBranch(string $branchName, string $message = ''): void
+    {
+        $process = new Process(['git', 'branch', '--show-current'], $this->checkout);
+        $process->run();
+
+        self::assertTrue($process->isSuccessful(), 'git branch --show-current failed');
+        $output = $process->getOutput();
+        self::assertEquals($branchName, trim($output), $message);
+    }
+}


### PR DESCRIPTION
| Q | A |
| - | - |
| New Feature | yes |
| RFC | #33 |
| BC Break | ? |

This patch adds a new interface, `BumpAndCommitChangelogVersion`, which describes classes that can update a changelog file to add a new version, and then commit and push the changes. I have included one implementation, `BumpAndCommitChangelogVersionViaKeepAChangelog` which uses utilities from phly/keep-a-changelog, as well as internal utilities, to do this.

I have added `BumpAndCommitChangelogVersion` as a dependency on `SwitchDefaultBranchToNextMinor`. The functionality is invoked only if a new release branch is made, and then immediately following that operation. At that time, the changelog is updated with a stub for the next **minor** version.

I have created a new command, `laminas:releases:bump-changelog`, implemented by `BumpChangelogForReleaseBranch`, which determines the release version and release branch, and uses those to call the composed `BumpAndCommitChangelogVersion`, this time bumping the changelog to the next **patch** version on the **originating** release branch.

Finally, I updated the sample workflow to call `laminas:releases:bump-changelog` as the final action in the workflow.  This approach guarantees that the newly-created `vNEXT` release branch does NOT contain a stub for the next patch release; only the originating branch will.

Fixes #33