### PR TITLE
Do not checkout the branch passed to `CommitFileViaConsole`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#41](https://github.com/laminas/automatic-releases/pull/41) fixes an issue that occurred when attempting to commit changes to the `CHANGELOG.md`.
 
 ## 1.1.0 - 2020-08-06
 

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -67,7 +67,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
         $bumper->updateChangelog($newVersion);
 
         $message = sprintf(self::COMMIT_TEMPLATE, $newVersion, self::CHANGELOG_FILE, $newVersion);
-        Assert::stringNotEmpty($message);
+        Assert::notEmpty($message);
 
         ($this->commitFile)(
             $repositoryDirectory,

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -66,11 +66,14 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
         Assert::stringNotEmpty($newVersion);
         $bumper->updateChangelog($newVersion);
 
+        $message = sprintf(self::COMMIT_TEMPLATE, $newVersion, self::CHANGELOG_FILE, $newVersion);
+        Assert::stringNotEmpty($message);
+
         ($this->commitFile)(
             $repositoryDirectory,
             $sourceBranch,
             self::CHANGELOG_FILE,
-            sprintf(self::COMMIT_TEMPLATE, $newVersion, self::CHANGELOG_FILE, $newVersion)
+            $message
         );
 
         ($this->push)($repositoryDirectory, $sourceBranch->name());

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -15,6 +15,7 @@ use Phly\KeepAChangelog\Version\ReadyLatestChangelogEvent;
 use Phly\KeepAChangelog\Version\SetDateForChangelogReleaseListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\NullOutput;
+use Webmozart\Assert\Assert;
 
 use function file_exists;
 use function sprintf;
@@ -69,11 +70,14 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
             return;
         }
 
+        $message = sprintf(self::COMMIT_TEMPLATE, $versionString, self::CHANGELOG_FILE);
+        Assert::stringNotEmpty($message);
+
         ($this->commitFile)(
             $repositoryDirectory,
             $sourceBranch,
             self::CHANGELOG_FILE,
-            sprintf(self::COMMIT_TEMPLATE, $versionString, self::CHANGELOG_FILE)
+            $message
         );
 
         ($this->push)($repositoryDirectory, $sourceBranch->name());

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -71,7 +71,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         }
 
         $message = sprintf(self::COMMIT_TEMPLATE, $versionString, self::CHANGELOG_FILE);
-        Assert::stringNotEmpty($message);
+        Assert::notEmpty($message);
 
         ($this->commitFile)(
             $repositoryDirectory,

--- a/src/Git/CommitFile.php
+++ b/src/Git/CommitFile.php
@@ -8,6 +8,11 @@ use Laminas\AutomaticReleases\Git\Value\BranchName;
 
 interface CommitFile
 {
+    /**
+     * @psalm-param non-empty-string $repositoryDirectory
+     * @psalm-param non-empty-string $filename
+     * @psalm-param non-empty-string $commitMessage
+     */
     public function __invoke(
         string $repositoryDirectory,
         BranchName $sourceBranch,

--- a/src/Git/CommitFileViaConsole.php
+++ b/src/Git/CommitFileViaConsole.php
@@ -19,7 +19,7 @@ final class CommitFileViaConsole implements CommitFile
         string $filename,
         string $commitMessage
     ): void {
-        $this->assertBranch($sourceBranch, $repositoryDirectory, $filename);
+        $this->assertWeAreOnBranch($sourceBranch, $repositoryDirectory, $filename);
 
         (new Process(['git', 'add', $filename], $repositoryDirectory))
             ->mustRun();
@@ -34,18 +34,13 @@ final class CommitFileViaConsole implements CommitFile
      * @param non-empty-string $repositoryDirectory
      * @param non-empty-string $filename
      */
-    private function assertBranch(
+    private function assertWeAreOnBranch(
         BranchName $expectedBranch,
         string $repositoryDirectory,
         string $filename
     ): void {
         $process = new Process(['git', 'branch', '--show-current'], $repositoryDirectory);
-        $process->run();
-
-        Assert::true($process->isSuccessful(), sprintf(
-            'Unable to determine current branch name for commit operation of file %s',
-            $filename
-        ));
+        $process->mustRun();
 
         $output = trim($process->getOutput());
 


### PR DESCRIPTION
We need to assume we're on the correct branch; otherwise, a checkout operation will lead to an error, aborting the operation.

Instead, I've added functionality to verify that we are on the branch provided; if not, an exception is raised.

The changes also required annotating that the repository directory, filename, and commit message arguments could not be empty, which required changes elsewhere to ensure this is true before calling on `CommitFile`.