### PR TITLE
Update Dockerfile to have modern toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:1 AS composer
 
-FROM php:7.4-cli
+FROM ubuntu:20.04
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
@@ -16,12 +16,22 @@ LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
 WORKDIR /app
 
 RUN apt update \
+    && apt install -y software-properties-common \
+    && apt clean
+
+RUN add-apt-repository -y ppa:ondrej/php \
     && apt install -y \
         git \
         gnupg \
         libzip-dev \
         zip \
-    && docker-php-ext-install zip \
+        php7.4-cli \
+        php7.4-curl \
+        php7.4-json \
+        php7.4-mbstring \
+        php7.4-readline \
+        php7.4-xml \
+        php7.4-zip \
     && apt clean
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ WORKDIR /app
 
 RUN apt update \
     && apt install -y software-properties-common \
-    && apt clean
-
-RUN add-apt-repository -y ppa:ondrej/php \
+    && add-apt-repository -y ppa:ondrej/php \
     && apt install -y \
         git \
         gnupg \
@@ -33,7 +31,6 @@ RUN add-apt-repository -y ppa:ondrej/php \
         php7.4-xml \
         php7.4-zip \
     && apt clean
-
 
 ADD composer.json /app/composer.json
 ADD composer.lock /app/composer.lock


### PR DESCRIPTION
We need a more recent git version, with 1.22 as the minimum. This patch updates the Dockerfile to use Ubuntu 20.04 as base image, adds the ondrej repository, and installs PHP with the extensions we need in order to run the tooling.