### PR TITLE
Fix which branch the minor release bump in the changelog targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#43](https://github.com/laminas/automatic-releases/pull/43) fixes which branch the minor changelog bump is targetted to to correctly be the next default branch.
 
 ## 1.2.0 - 2020-08-12
 

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -81,7 +81,7 @@ final class SwitchDefaultBranchToNextMinor extends Command
                 BumpAndCommitChangelogVersion::BUMP_MINOR,
                 $repositoryPath,
                 $releaseVersion,
-                $newestBranch
+                $nextDefaultBranch
             );
         }
 

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -171,7 +171,7 @@ JSON
                 BumpAndCommitChangelogVersion::BUMP_MINOR,
                 $workspace,
                 SemVerVersion::fromMilestoneName('1.2.3'),
-                BranchName::fromName('1.2.x')
+                BranchName::fromName('1.3.x')
             );
 
         $this->setDefaultBranch->expects(self::once())


### PR DESCRIPTION
When creating a new release branch and bumping the changelog version, use the next default branch, not the newest existing.