### PR TITLE
Fix YAML config for actions-tagger workflow

### DIFF
--- a/.github/workflows/update-major-release.yml
+++ b/.github/workflows/update-major-release.yml
@@ -4,9 +4,7 @@ name: "Keep major release version up-to-date"
 
 on:
   release:
-    types:
-      - published
-      - edited
+    types: [published]
 
 jobs:
   actions-tagger:
@@ -17,4 +15,4 @@ jobs:
           publish_latest_tag: false
           prefer_branch_releases: false
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
Updated how the "types" configuration for the release action are defined, and limited to only "published".

Additionally, working examples I saw all used a different format for defining env variables, so I went with what appears to work.