### PR TITLE
Idempotent operations for reading, checkout branch prior to writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#47](https://github.com/laminas/automatic-releases/pull/47) fixes `CHANGELOG.md` update operations to avoid preventable failures during the release process.
 
 ## 1.2.1 - 2020-08-12
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -72,7 +72,13 @@ use const STDERR;
     $checkoutBranch       = new CheckoutBranchViaConsole();
     $commit               = new CommitFileViaConsole();
     $push                 = new PushViaConsole();
-    $commitChangelog      = new CommitReleaseChangelogViaKeepAChangelog(new SystemClock(), $commit, $push, $logger);
+    $commitChangelog      = new CommitReleaseChangelogViaKeepAChangelog(
+        new SystemClock(),
+        $checkoutBranch,
+        $commit,
+        $push,
+        $logger
+    );
     $createCommitText     = new CreateReleaseTextThroughChangelog(JwageGenerateChangelog::create(
         $makeRequests,
         $httpClient

--- a/bin/console.php
+++ b/bin/console.php
@@ -13,6 +13,7 @@ use Laminas\AutomaticReleases\Application\Command\CreateMergeUpPullRequest;
 use Laminas\AutomaticReleases\Application\Command\ReleaseCommand;
 use Laminas\AutomaticReleases\Application\Command\SwitchDefaultBranchToNextMinor;
 use Laminas\AutomaticReleases\Changelog\BumpAndCommitChangelogVersionViaKeepAChangelog;
+use Laminas\AutomaticReleases\Changelog\ChangelogExistsViaConsole;
 use Laminas\AutomaticReleases\Changelog\CommitReleaseChangelogViaKeepAChangelog;
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
 use Laminas\AutomaticReleases\Git\CheckoutBranchViaConsole;
@@ -69,11 +70,13 @@ use const STDERR;
         $httpClient,
         $githubToken
     ));
+    $changelogExists      = new ChangelogExistsViaConsole();
     $checkoutBranch       = new CheckoutBranchViaConsole();
     $commit               = new CommitFileViaConsole();
     $push                 = new PushViaConsole();
     $commitChangelog      = new CommitReleaseChangelogViaKeepAChangelog(
         new SystemClock(),
+        $changelogExists,
         $checkoutBranch,
         $commit,
         $push,
@@ -84,7 +87,7 @@ use const STDERR;
         $httpClient
     ));
     $createReleaseText    = new ConcatenateMultipleReleaseTexts([
-        new CreateReleaseTextViaKeepAChangelog(),
+        new CreateReleaseTextViaKeepAChangelog($changelogExists),
         $createCommitText,
     ]);
     $createRelease        = new CreateReleaseThroughApiCall(
@@ -93,6 +96,7 @@ use const STDERR;
         $githubToken
     );
     $bumpChangelogVersion = new BumpAndCommitChangelogVersionViaKeepAChangelog(
+        $changelogExists,
         $checkoutBranch,
         $commit,
         $push,

--- a/src/Changelog/ChangelogExists.php
+++ b/src/Changelog/ChangelogExists.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Changelog;
+
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+
+interface ChangelogExists
+{
+    /**
+     * @param non-empty-string $repositoryDirectory
+     */
+    public function __invoke(
+        BranchName $sourceBranch,
+        string $repositoryDirectory
+    ): bool;
+}

--- a/src/Changelog/ChangelogExistsViaConsole.php
+++ b/src/Changelog/ChangelogExistsViaConsole.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Changelog;
+
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Symfony\Component\Process\Process;
+
+class ChangelogExistsViaConsole implements ChangelogExists
+{
+    /**
+     * @param non-empty-string $repositoryDirectory
+     */
+    public function __invoke(
+        BranchName $sourceBranch,
+        string $repositoryDirectory
+    ): bool {
+        $process = new Process(['git', 'show', $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -206,6 +206,8 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
         file_put_contents($changelogFile, self::CHANGELOG_STUB);
 
         (new Process(['git', 'init', '.'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'me@example.com'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Just Me'], $repo))->mustRun();
         (new Process(['git', 'add', '.'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();

--- a/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
+++ b/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
@@ -82,6 +82,8 @@ class ChangelogExistsViaConsoleTest extends TestCase
         );
 
         (new Process(['git', 'init', '.'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'me@example.com'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Just Me'], $repo))->mustRun();
         (new Process(['git', 'add', '.'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();

--- a/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
+++ b/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Changelog;
+
+use Laminas\AutomaticReleases\Changelog\ChangelogExistsViaConsole;
+use Laminas\AutomaticReleases\Git\Value\BranchName;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
+
+use function file_put_contents;
+use function Safe\tempnam;
+use function sprintf;
+use function sys_get_temp_dir;
+use function unlink;
+
+class ChangelogExistsViaConsoleTest extends TestCase
+{
+    public function testReturnsFalseWhenChangelogIsNotPresentInBranch(): void
+    {
+        self::assertFalse(
+            (new ChangelogExistsViaConsole())(
+                BranchName::fromName('0.99.x'),
+                $this->createMockRepositoryWithChangelog()
+            )
+        );
+    }
+
+    public function testReturnsTrueWhenChangelogIsPresentInBranch(): void
+    {
+        self::assertTrue(
+            (new ChangelogExistsViaConsole())(
+                BranchName::fromName('1.0.x'),
+                $this->createMockRepositoryWithChangelog()
+            )
+        );
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    private function createMockRepositoryWithChangelog(): string
+    {
+        $repo = tempnam(sys_get_temp_dir(), 'ChangelogExists');
+        Assert::notEmpty($repo);
+        unlink($repo);
+
+        (new Process(['mkdir', '-p', $repo]))->mustRun();
+
+        file_put_contents(
+            sprintf('%s/%s', $repo, 'CHANGELOG.md'),
+            <<< 'CHANGELOG'
+                # Changelog
+                
+                All notable changes to this project will be documented in this file, in reverse chronological order by release.
+                        
+                ## 1.0.0 - %s
+                
+                ### Added
+                
+                - Everything.
+                
+                ### Changed
+                
+                - Nothing.
+                
+                ### Deprecated
+                
+                - Nothing.
+                
+                ### Removed
+                
+                - Nothing.
+                
+                ### Fixed
+                
+                - Nothing.
+                
+                CHANGELOG
+        );
+
+        (new Process(['git', 'init', '.'], $repo))->mustRun();
+        (new Process(['git', 'add', '.'], $repo))->mustRun();
+        (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
+        (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();
+
+        return $repo;
+    }
+}

--- a/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
@@ -204,6 +204,8 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
         );
 
         (new Process(['git', 'init', '.'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'me@example.com'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Just Me'], $repo))->mustRun();
         (new Process(['git', 'add', '.'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();

--- a/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Test\Unit\Changelog;
 
 use DateTimeImmutable;
+use Laminas\AutomaticReleases\Changelog\ChangelogExistsViaConsole;
 use Laminas\AutomaticReleases\Changelog\CommitReleaseChangelogViaKeepAChangelog;
 use Laminas\AutomaticReleases\Git\CheckoutBranch;
 use Laminas\AutomaticReleases\Git\CommitFile;
@@ -53,6 +54,7 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
 
         $this->releaseChangelog = new CommitReleaseChangelogViaKeepAChangelog(
             $this->clock,
+            new ChangelogExistsViaConsole(),
             $this->checkoutBranch,
             $this->commitFile,
             $this->push,

--- a/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
+++ b/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Github;
 
+use Laminas\AutomaticReleases\Changelog\ChangelogExistsViaConsole;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Milestone;
@@ -30,7 +31,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
         );
 
         self::assertFalse(
-            (new CreateReleaseTextViaKeepAChangelog())
+            (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
                 ->canCreateReleaseText(
                     $this->createMockMilestone(),
                     RepositoryName::fromFullName('example/repo'),
@@ -49,7 +50,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
         );
 
         self::assertFalse(
-            (new CreateReleaseTextViaKeepAChangelog())
+            (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
                 ->canCreateReleaseText(
                     $this->createMockMilestone(),
                     RepositoryName::fromFullName('example/repo'),
@@ -69,7 +70,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
         );
 
         self::assertTrue(
-            (new CreateReleaseTextViaKeepAChangelog())
+            (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
                 ->canCreateReleaseText(
                     $this->createMockMilestone(),
                     RepositoryName::fromFullName('example/repo'),
@@ -113,7 +114,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
 
         self::assertSame(
             $expected,
-            (new CreateReleaseTextViaKeepAChangelog())
+            (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
                 ->__invoke(
                     $this->createMockMilestone(),
                     RepositoryName::fromFullName('example/repo'),

--- a/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
+++ b/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
@@ -162,6 +162,8 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
 
         (new Process(['git', 'init', '.'], $repo))->mustRun();
         (new Process(['git', 'add', '.'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'me@example.com'], $repo))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'Just Me'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();
 

--- a/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
+++ b/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
@@ -159,6 +159,11 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
             $template
         );
 
+        (new Process(['git', 'init', '.'], $repo))->mustRun();
+        (new Process(['git', 'add', '.'], $repo))->mustRun();
+        (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
+        (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();
+
         return $repo;
     }
 


### PR DESCRIPTION
| Q | A |
| - | - |
| BC Break? | No |
| Bug?      | Yes — #46 |

This patch does the following:

- Adds  the interface `ChangelogExists`, with one implementation, `ChangelogExistsViaConsole`. The functionality is intended to be used whenever we want to check for existence of a changelog on a given branch, and is idempotent (it uses the exit code of `git show {REF}:CHANGELOG.md` to determine existence).

- Any operation that needs to check for existence of the changelog now composes an instance of `ChangelogExists` for that purpose.

- Operations that only _read_  the `CHANGELOG.md` now do so using `git show {REF}:CHANGELOG.md`.This change was introduced to  `CreateReleaseTextViaKeepAChangelog`.

- Any operation that will _write_ to the CHANGELOG.md now first uses `ChangelogExists` to test for the file, and then performs a `CheckoutBranch` operation to ensure that the correct version is updated, and to ensure we push back to the correct branch. Specifically, I updated `CreateReleaseTextViaKeepAChangelog` to compose a `CheckoutBranch` instance for use after determining changes can be made.

This should resolve all remaining issues regarding updates to the changelog file.