### PR TITLE
When using the REST API, send "token" authorization instead of "bearer"

### DIFF
--- a/src/Github/Api/V3/CreatePullRequestThroughApiCall.php
+++ b/src/Github/Api/V3/CreatePullRequestThroughApiCall.php
@@ -48,7 +48,7 @@ final class CreatePullRequestThroughApiCall implements CreatePullRequest
             )
             ->withAddedHeader('Content-Type', 'application/json')
             ->withAddedHeader('User-Agent', 'Ocramius\'s minimal API V3 client')
-            ->withAddedHeader('Authorization', 'bearer ' . $this->apiToken);
+            ->withAddedHeader('Authorization', 'token ' . $this->apiToken);
 
         $request
             ->getBody()

--- a/src/Github/Api/V3/CreateReleaseThroughApiCall.php
+++ b/src/Github/Api/V3/CreateReleaseThroughApiCall.php
@@ -49,7 +49,7 @@ final class CreateReleaseThroughApiCall implements CreateRelease
             )
             ->withAddedHeader('Content-Type', 'application/json')
             ->withAddedHeader('User-Agent', 'Ocramius\'s minimal API V3 client')
-            ->withAddedHeader('Authorization', 'bearer ' . $this->apiToken);
+            ->withAddedHeader('Authorization', 'token ' . $this->apiToken);
 
         $request
             ->getBody()

--- a/src/Github/Api/V3/SetDefaultBranchThroughApiCall.php
+++ b/src/Github/Api/V3/SetDefaultBranchThroughApiCall.php
@@ -45,7 +45,7 @@ final class SetDefaultBranchThroughApiCall implements SetDefaultBranch
             )
             ->withAddedHeader('Content-Type', 'application/json')
             ->withAddedHeader('User-Agent', 'Ocramius\'s minimal API V3 client')
-            ->withAddedHeader('Authorization', 'bearer ' . $this->apiToken);
+            ->withAddedHeader('Authorization', 'token ' . $this->apiToken);
 
         $request
             ->getBody()

--- a/test/unit/Github/Api/V3/CreatePullRequestTest.php
+++ b/test/unit/Github/Api/V3/CreatePullRequestTest.php
@@ -76,7 +76,7 @@ JSON
                         'Host'          => ['the-domain.com'],
                         'Content-Type'  => ['application/json'],
                         'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
-                        'Authorization' => ['bearer ' . $this->apiToken],
+                        'Authorization' => ['token ' . $this->apiToken],
                     ],
                     $request->getHeaders()
                 );

--- a/test/unit/Github/Api/V3/CreateReleaseTest.php
+++ b/test/unit/Github/Api/V3/CreateReleaseTest.php
@@ -74,7 +74,7 @@ JSON
                         'Host'          => ['the-domain.com'],
                         'Content-Type'  => ['application/json'],
                         'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
-                        'Authorization' => ['bearer ' . $this->apiToken],
+                        'Authorization' => ['token ' . $this->apiToken],
                     ],
                     $request->getHeaders()
                 );

--- a/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
+++ b/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
@@ -72,7 +72,7 @@ final class SetDefaultBranchThroughApiCallTest extends TestCase
                         'Host'          => ['the-domain.com'],
                         'Content-Type'  => ['application/json'],
                         'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
-                        'Authorization' => ['bearer ' . $this->apiToken],
+                        'Authorization' => ['token ' . $this->apiToken],
                     ],
                     $request->getHeaders()
                 );
@@ -117,7 +117,7 @@ final class SetDefaultBranchThroughApiCallTest extends TestCase
                         'Host'          => ['the-domain.com'],
                         'Content-Type'  => ['application/json'],
                         'User-Agent'    => ['Ocramius\'s minimal API V3 client'],
-                        'Authorization' => ['bearer ' . $this->apiToken],
+                        'Authorization' => ['token ' . $this->apiToken],
                     ],
                     $request->getHeaders()
                 );


### PR DESCRIPTION
Since our GITHUB_TOKEN is a personal access token, it can be used as either an OAuth (bearer) or PAT (token) type for purposes of authorization. However, OAuth requests from actions do not trigger workflow events (see https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token).

This patch updates the three different API calls we currently perform (create release, set default branch, create pull request) to use the "token" type for authorization.