### PR TITLE
Use ORGANIZATION_ADMIN_TOKEN for our own release action

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           command-name: "laminas:automatic-releases:release"
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
@@ -51,7 +51,7 @@ jobs:
         with:
           command-name: "laminas:automatic-releases:bump-changelog"
         env:
-          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
To ensure it can trigger workflow events.

Additionally, this modifies the bump-changelog action to NOT use the ORGANIZATION_ADMIN_TOKEN, as it is not needed.

No milestone associated, as it's for this repo only, not for those consuming the action.