### PR TITLE
Check for changelog and/or pull contents from changelog using remote origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#55](https://github.com/laminas/automatic-releases/pull/55) fixes issues with identifying and retrieving `CHANGELOG.md` contents from non-default branches.
 
 ## 1.2.3 - 2020-08-13
 

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -53,7 +53,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
     ): void {
         if (! ($this->changelogExists)($sourceBranch, $repositoryDirectory)) {
             // No changelog
-            $this->logger->info('BumpAndCommitChangelog: No CHANGELOG.md file detected');
+            $this->logger->info('BumpAndCommitChangelogVersion: No CHANGELOG.md file detected');
 
             return;
         }
@@ -81,7 +81,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
         ($this->push)($repositoryDirectory, $sourceBranch->name());
 
         $this->logger->info(sprintf(
-            'BumpAndCommitChangelog: bumped %s to version %s in branch %s',
+            'BumpAndCommitChangelogVersion: bumped %s to version %s in branch %s',
             self::CHANGELOG_FILE,
             $newVersion,
             $sourceBranch->name()

--- a/src/Changelog/ChangelogExistsViaConsole.php
+++ b/src/Changelog/ChangelogExistsViaConsole.php
@@ -16,7 +16,7 @@ class ChangelogExistsViaConsole implements ChangelogExists
         BranchName $sourceBranch,
         string $repositoryDirectory
     ): bool {
-        $process = new Process(['git', 'show', $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
+        $process = new Process(['git', 'show', 'origin/' . $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
         $process->run();
 
         return $process->isSuccessful();

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -63,7 +63,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
     ): void {
         if (! ($this->changelogExists)($sourceBranch, $repositoryDirectory)) {
             // No changelog
-            $this->logger->info('No CHANGELOG.md file detected');
+            $this->logger->info('CommitReleaseChangelog: No CHANGELOG.md file detected');
 
             return;
         }
@@ -99,7 +99,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
 
         if ($event->failed()) {
             $this->logger->info(sprintf(
-                'Failed to find release version "%s" in "%s"',
+                'CommitReleaseChangelog: Failed to find release version "%s" in "%s"',
                 $versionString,
                 $changelogFile
             ));
@@ -111,7 +111,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
 
         if ($event->failed()) {
             $this->logger->info(sprintf(
-                'Failed setting release date for version "%s" in "%s"',
+                'CommitReleaseChangelog: Failed setting release date for version "%s" in "%s"',
                 $versionString,
                 $changelogFile
             ));
@@ -120,7 +120,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         }
 
         $this->logger->info(sprintf(
-            'Set release date for version "%s" in "%s" to "%s"',
+            'CommitReleaseChangelog: Set release date for version "%s" in "%s" to "%s"',
             $versionString,
             $changelogFile,
             $this->clock->now()->format('Y-m-d')

--- a/src/Git/CommitFileViaConsole.php
+++ b/src/Git/CommitFileViaConsole.php
@@ -45,9 +45,10 @@ final class CommitFileViaConsole implements CommitFile
         $output = trim($process->getOutput());
 
         Assert::same($output, $expectedBranch->name(), sprintf(
-            'Cannot commit file %s to branch %s, as a different branch is currently checked out.',
+            'CommitFile: Cannot commit file %s to branch %s, as a different branch is currently checked out (%s).',
             $filename,
-            $expectedBranch->name()
+            $expectedBranch->name(),
+            $output
         ));
     }
 }

--- a/src/Github/CreateReleaseTextViaKeepAChangelog.php
+++ b/src/Github/CreateReleaseTextViaKeepAChangelog.php
@@ -76,7 +76,7 @@ class CreateReleaseTextViaKeepAChangelog implements CreateReleaseText
         BranchName $sourceBranch,
         string $repositoryDirectory
     ): string {
-        $process = new Process(['git', 'show', $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
+        $process = new Process(['git', 'show', 'origin/' . $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
         $process->mustRun();
 
         $contents = $process->getOutput();

--- a/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
+++ b/test/unit/Changelog/ChangelogExistsViaConsoleTest.php
@@ -20,20 +20,24 @@ class ChangelogExistsViaConsoleTest extends TestCase
 {
     public function testReturnsFalseWhenChangelogIsNotPresentInBranch(): void
     {
+        $repository = $this->createMockRepositoryWithChangelog();
+        $workingDir = $this->checkoutMockRepositoryWithChangelog($repository);
         self::assertFalse(
             (new ChangelogExistsViaConsole())(
                 BranchName::fromName('0.99.x'),
-                $this->createMockRepositoryWithChangelog()
+                $workingDir
             )
         );
     }
 
     public function testReturnsTrueWhenChangelogIsPresentInBranch(): void
     {
+        $repository = $this->createMockRepositoryWithChangelog();
+        $workingDir = $this->checkoutMockRepositoryWithChangelog($repository);
         self::assertTrue(
             (new ChangelogExistsViaConsole())(
                 BranchName::fromName('1.0.x'),
-                $this->createMockRepositoryWithChangelog()
+                $workingDir
             )
         );
     }
@@ -87,6 +91,21 @@ class ChangelogExistsViaConsoleTest extends TestCase
         (new Process(['git', 'add', '.'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();
+
+        return $repo;
+    }
+
+    /**
+     * @psalm-param non-empty-string $origin
+     * @psalm-return non-empty-string
+     */
+    private function checkoutMockRepositoryWithChangelog(string $origin): string
+    {
+        $repo = tempnam(sys_get_temp_dir(), 'CreateReleaseTextViaKeepAChangelog');
+        Assert::notEmpty($repo);
+        unlink($repo);
+
+        (new Process(['git', 'clone', $origin, $repo]))->mustRun();
 
         return $repo;
     }

--- a/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
+++ b/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
@@ -29,6 +29,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
             self::INVALID_CHANGELOG,
             'NOT-A-CHANGELOG.md'
         );
+        $workingPath    = $this->checkoutMockRepositoryWithChangelog($repositoryPath);
 
         self::assertFalse(
             (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
@@ -37,7 +38,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
                     RepositoryName::fromFullName('example/repo'),
                     SemVerVersion::fromMilestoneName('1.0.0'),
                     BranchName::fromName('1.0.x'),
-                    $repositoryPath
+                    $workingPath
                 )
         );
     }
@@ -48,6 +49,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
             self::INVALID_CHANGELOG,
             'CHANGELOG.md'
         );
+        $workingPath    = $this->checkoutMockRepositoryWithChangelog($repositoryPath);
 
         self::assertFalse(
             (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
@@ -56,7 +58,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
                     RepositoryName::fromFullName('example/repo'),
                     SemVerVersion::fromMilestoneName('1.0.0'),
                     BranchName::fromName('1.0.x'),
-                    $repositoryPath
+                    $workingPath
                 )
         );
     }
@@ -68,6 +70,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
             $changelogContents,
             'CHANGELOG.md'
         );
+        $workingPath       = $this->checkoutMockRepositoryWithChangelog($repositoryPath);
 
         self::assertTrue(
             (new CreateReleaseTextViaKeepAChangelog(new ChangelogExistsViaConsole()))
@@ -76,7 +79,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
                     RepositoryName::fromFullName('example/repo'),
                     SemVerVersion::fromMilestoneName('1.0.0'),
                     BranchName::fromName('1.0.x'),
-                    $repositoryPath
+                    $workingPath
                 )
         );
     }
@@ -89,6 +92,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
             $changelogContents,
             'CHANGELOG.md'
         );
+        $workingPath       = $this->checkoutMockRepositoryWithChangelog($repositoryPath);
 
         $expected = sprintf(<<< 'END'
             ### Added
@@ -120,7 +124,7 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
                     RepositoryName::fromFullName('example/repo'),
                     SemVerVersion::fromMilestoneName('1.0.0'),
                     BranchName::fromName('1.0.x'),
-                    $repositoryPath
+                    $workingPath
                 )
         );
     }
@@ -166,6 +170,21 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
         (new Process(['git', 'config', 'user.name', 'Just Me'], $repo))->mustRun();
         (new Process(['git', 'commit', '-m', 'Initial import'], $repo))->mustRun();
         (new Process(['git', 'switch', '-c', '1.0.x'], $repo))->mustRun();
+
+        return $repo;
+    }
+
+    /**
+     * @psalm-param non-empty-string $origin
+     * @psalm-return non-empty-string
+     */
+    private function checkoutMockRepositoryWithChangelog(string $origin): string
+    {
+        $repo = tempnam(sys_get_temp_dir(), 'CreateReleaseTextViaKeepAChangelog');
+        Assert::notEmpty($repo);
+        unlink($repo);
+
+        (new Process(['git', 'clone', $origin, $repo]))->mustRun();
 
         return $repo;
     }


### PR DESCRIPTION
| Q | A |
| - | - |
| Bugfix | #51 |
| BC Break | No |

As it turns out, while you can use `git show {ref}:{filename}` to both test for the existing of a file at a given reference, as well as display its contents, it only works if the reference is present.

When the github action starts, it _exports_ the default branch to the working directory. Our code then _fetches_ from the remote, which then sets the current branch to the _default_ branch, which may or may not be the branch we are releasing from. It's not until we do a checkout operation that the release branch can be guaranteed as a reference in the checkout.

The reference _does_ exist in the `origin` remote, and since we have all history, that means the content is present in our checkout; it's just that the reference doesn't exist **IN** the checkout.

As such, for idempotent operations where we are checking for the existence of a file, or pulling its contents, we need to qualify the reference with the remote name (e.g., `{remote}/1.0.x`). Since we can guarantee that the `origin` remote is present, we can use that remote name.

Fixes #51