### PR TITLE
Automatically generate changelog revision text if the changelog was not hand-crafted - do not commit if unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#58](https://github.com/laminas/automatic-releases/pull/58) updates the "Release" step such that:
+  - It now **always** uses jwage/changelog-generator to generate release notes.
+  - **IF** a `CHANGELOG.md` file is present:
+    - **IF** it contains changes for the target version, it appends the generated release notes to the changes for that version.
+    - **OTHERWISE** it replaces the contents for the target version with the generated release notes.
+    - And then it commits and pushes the file to the originating branch before it tags and releases.
 
 ### Deprecated
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -27,11 +27,11 @@ use Laminas\AutomaticReleases\Github\Api\GraphQL\RunGraphQLQuery;
 use Laminas\AutomaticReleases\Github\Api\V3\CreatePullRequestThroughApiCall;
 use Laminas\AutomaticReleases\Github\Api\V3\CreateReleaseThroughApiCall;
 use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranchThroughApiCall;
-use Laminas\AutomaticReleases\Github\ConcatenateMultipleReleaseTexts;
 use Laminas\AutomaticReleases\Github\CreateReleaseTextThroughChangelog;
 use Laminas\AutomaticReleases\Github\CreateReleaseTextViaKeepAChangelog;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEventFromGithubActionPath;
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
+use Laminas\AutomaticReleases\Github\MergeMultipleReleaseNotes;
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use Lcobucci\Clock\SystemClock;
 use Monolog\Handler\StreamHandler;
@@ -75,7 +75,6 @@ use const STDERR;
     $commit               = new CommitFileViaConsole();
     $push                 = new PushViaConsole();
     $commitChangelog      = new CommitReleaseChangelogViaKeepAChangelog(
-        new SystemClock(),
         $changelogExists,
         $checkoutBranch,
         $commit,
@@ -86,8 +85,8 @@ use const STDERR;
         $makeRequests,
         $httpClient
     ));
-    $createReleaseText    = new ConcatenateMultipleReleaseTexts([
-        new CreateReleaseTextViaKeepAChangelog($changelogExists),
+    $createReleaseText    = new MergeMultipleReleaseNotes([
+        new CreateReleaseTextViaKeepAChangelog($changelogExists, new SystemClock()),
         $createCommitText,
     ]);
     $createRelease        = new CreateReleaseThroughApiCall(

--- a/examples/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
+++ b/examples/.github/workflows/release-on-milestone-closed-triggering-release-event.yml
@@ -1,0 +1,57 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "Automatic Releases"
+
+on:
+  milestone:
+    types:
+      - "closed"
+
+jobs:
+  release:
+    name: "GIT tag, release & create merge-up PR"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Release"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:release"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create Merge-Up Pull Request"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:create-merge-up-pull-request"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Create and/or Switch to new Release Branch"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+
+      - name: "Bump Changelog Version On Originating Release Branch"
+        uses: "laminas/automatic-releases@v1"
+        with:
+          command-name: "laminas:automatic-releases:bump-changelog"
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/src/Application/Command/CreateMergeUpPullRequest.php
+++ b/src/Application/Command/CreateMergeUpPullRequest.php
@@ -94,19 +94,21 @@ final class CreateMergeUpPullRequest extends Command
             . uniqid('_', true) // This is to ensure that a new merge-up pull request is created even if one already exists
         );
 
+        $releaseNotes = $this->createReleaseText->__invoke(
+            $this->getMilestone->__invoke($event->repository(), $event->milestoneNumber()),
+            $event->repository(),
+            $event->version(),
+            $releaseBranch,
+            $repositoryPath
+        );
+
         $this->push->__invoke($repositoryPath, $releaseBranch->name(), $mergeUpBranch->name());
         $this->createPullRequest->__invoke(
             $event->repository(),
             $mergeUpBranch,
             $mergeUpTarget,
             'Merge release ' . $releaseVersion->fullReleaseName() . ' into ' . $mergeUpTarget->name(),
-            $this->createReleaseText->__invoke(
-                $this->getMilestone->__invoke($event->repository(), $event->milestoneNumber()),
-                $event->repository(),
-                $event->version(),
-                $releaseBranch,
-                $repositoryPath
-            )
+            $releaseNotes->contents()
         );
 
         return 0;

--- a/src/Application/Command/ReleaseCommand.php
+++ b/src/Application/Command/ReleaseCommand.php
@@ -84,9 +84,7 @@ final class ReleaseCommand extends Command
             sprintf('No valid release branch found for version %s', $releaseVersion->fullReleaseName())
         );
 
-        ($this->commitChangelog)($repositoryPath, $releaseVersion, $releaseBranch);
-
-        $changelog = ($this->createChangelogText)(
+        $changelogReleaseNotes = ($this->createChangelogText)(
             $milestone,
             $repositoryName,
             $releaseVersion,
@@ -94,12 +92,20 @@ final class ReleaseCommand extends Command
             $repositoryPath
         );
 
+        ($this->commitChangelog)($changelogReleaseNotes, $repositoryPath, $releaseVersion, $releaseBranch);
+
         $tagName = $releaseVersion->fullReleaseName();
 
-        ($this->createTag)($repositoryPath, $releaseBranch, $tagName, $changelog, $this->environment->signingSecretKey());
+        ($this->createTag)(
+            $repositoryPath,
+            $releaseBranch,
+            $tagName,
+            $changelogReleaseNotes->contents(),
+            $this->environment->signingSecretKey()
+        );
         ($this->push)($repositoryPath, $tagName);
         ($this->push)($repositoryPath, $tagName, $releaseVersion->targetReleaseBranchName()->name());
-        ($this->createRelease)($repositoryName, $releaseVersion, $changelog);
+        ($this->createRelease)($repositoryName, $releaseVersion, $changelogReleaseNotes->contents());
 
         return 0;
     }

--- a/src/Changelog/ChangelogReleaseNotes.php
+++ b/src/Changelog/ChangelogReleaseNotes.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Changelog;
+
+use Phly\KeepAChangelog\Common\ChangelogEditor;
+use Phly\KeepAChangelog\Common\ChangelogEntry;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+class ChangelogReleaseNotes
+{
+    private const CONCATENATION_STRING = "\n\n-----\n\n";
+
+    private ?ChangelogEntry $changelogEntry;
+
+    /** @psalm-var non-empty-string */
+    private string $contents;
+
+    /**
+     * @psalm-param non-empty-string $contents
+     */
+    public function __construct(
+        string $contents,
+        ?ChangelogEntry $changelogEntry = null
+    ) {
+        $this->contents       = $contents;
+        $this->changelogEntry = $changelogEntry;
+    }
+
+    /**
+     * @psalm-return non-empty-string
+     */
+    public function contents(): string
+    {
+        return $this->contents;
+    }
+
+    public function merge(self $next): self
+    {
+        if ($this->changelogEntry && $next->changelogEntry) {
+            throw new RuntimeException(
+                'Aborting: Both current release notes and next contain a ChangelogEntry;'
+                . ' only one CreateReleaseText implementation should resolve one.'
+            );
+        }
+
+        $merged                 = clone $this;
+        $merged->contents      .= self::CONCATENATION_STRING . $next->contents;
+        $merged->changelogEntry = $merged->changelogEntry ?: $next->changelogEntry;
+
+        return $merged;
+    }
+
+    public function requiresUpdatingChangelogFile(): bool
+    {
+        if ($this->changelogEntry === null) {
+            return false;
+        }
+
+        $originalContents = (string) $this->changelogEntry->contents();
+
+        return $this->contents !== $originalContents;
+    }
+
+    /**
+     * @psalm-param non-empty-string $changelogFile
+     */
+    public function writeChangelogFile(string $changelogFile): void
+    {
+        // Nothing to do
+        if (! $this->requiresUpdatingChangelogFile()) {
+            return;
+        }
+
+        Assert::notNull($this->changelogEntry);
+
+        $editor = new ChangelogEditor();
+        $editor->update(
+            $changelogFile,
+            $this->contents,
+            $this->changelogEntry
+        );
+    }
+}

--- a/src/Changelog/CommitReleaseChangelog.php
+++ b/src/Changelog/CommitReleaseChangelog.php
@@ -13,6 +13,7 @@ interface CommitReleaseChangelog
      * @psalm-param non-empty-string $repositoryDirectory
      */
     public function __invoke(
+        ChangelogReleaseNotes $releaseNotes,
         string $repositoryDirectory,
         SemVerVersion $version,
         BranchName $sourceBranch

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -9,13 +9,7 @@ use Laminas\AutomaticReleases\Git\CommitFile;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
-use Lcobucci\Clock\Clock;
-use Phly\KeepAChangelog\Common\DiscoverChangelogEntryListener;
-use Phly\KeepAChangelog\Config;
-use Phly\KeepAChangelog\Version\ReadyLatestChangelogEvent;
-use Phly\KeepAChangelog\Version\SetDateForChangelogReleaseListener;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Output\NullOutput;
 use Webmozart\Assert\Assert;
 
 use function sprintf;
@@ -30,7 +24,6 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         Updates the %s to set the release date.
         COMMIT;
 
-    private Clock $clock;
     private ChangelogExists $changelogExists;
     private CheckoutBranch $checkoutBranch;
     private CommitFile $commitFile;
@@ -38,14 +31,12 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
     private LoggerInterface $logger;
 
     public function __construct(
-        Clock $clock,
         ChangelogExists $changelogExists,
         CheckoutBranch $checkoutBranch,
         CommitFile $commitFile,
         Push $push,
         LoggerInterface $logger
     ) {
-        $this->clock           = $clock;
         $this->changelogExists = $changelogExists;
         $this->checkoutBranch  = $checkoutBranch;
         $this->commitFile      = $commitFile;
@@ -57,10 +48,18 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
      * @psalm-param non-empty-string $repositoryDirectory
      */
     public function __invoke(
+        ChangelogReleaseNotes $releaseNotes,
         string $repositoryDirectory,
         SemVerVersion $version,
         BranchName $sourceBranch
     ): void {
+        if (! $releaseNotes->requiresUpdatingChangelogFile()) {
+            // Nothing to commit
+            $this->logger->info('CommitReleaseChangelog: no changes to commit.');
+
+            return;
+        }
+
         if (! ($this->changelogExists)($sourceBranch, $repositoryDirectory)) {
             // No changelog
             $this->logger->info('CommitReleaseChangelog: No CHANGELOG.md file detected');
@@ -68,17 +67,14 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
             return;
         }
 
-        $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
-        $versionString = $version->fullReleaseName();
-
         ($this->checkoutBranch)($repositoryDirectory, $sourceBranch);
 
-        if (! $this->updateChangelog($changelogFile, $versionString)) {
-            // Failure to update; nothing to commit
-            return;
-        }
+        $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
+        Assert::stringNotEmpty($changelogFile);
 
-        $message = sprintf(self::COMMIT_TEMPLATE, $versionString, self::CHANGELOG_FILE);
+        $releaseNotes->writeChangelogFile($changelogFile);
+
+        $message = sprintf(self::COMMIT_TEMPLATE, $version->fullReleaseName(), self::CHANGELOG_FILE);
         Assert::notEmpty($message);
 
         ($this->commitFile)(
@@ -89,105 +85,5 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         );
 
         ($this->push)($repositoryDirectory, $sourceBranch->name());
-    }
-
-    private function updateChangelog(string $changelogFile, string $versionString): bool
-    {
-        $event = $this->createReadyLatestChangelogEvent($changelogFile, $versionString);
-
-        (new DiscoverChangelogEntryListener())($event);
-
-        if ($event->failed()) {
-            $this->logger->info(sprintf(
-                'CommitReleaseChangelog: Failed to find release version "%s" in "%s"',
-                $versionString,
-                $changelogFile
-            ));
-
-            return false;
-        }
-
-        (new SetDateForChangelogReleaseListener())($event);
-
-        if ($event->failed()) {
-            $this->logger->info(sprintf(
-                'CommitReleaseChangelog: Failed setting release date for version "%s" in "%s"',
-                $versionString,
-                $changelogFile
-            ));
-
-            return false;
-        }
-
-        $this->logger->info(sprintf(
-            'CommitReleaseChangelog: Set release date for version "%s" in "%s" to "%s"',
-            $versionString,
-            $changelogFile,
-            $this->clock->now()->format('Y-m-d')
-        ));
-
-        return true;
-    }
-
-    private function createReadyLatestChangelogEvent(
-        string $changelogFile,
-        string $versionString
-    ): ReadyLatestChangelogEvent {
-        /**
-         * Hard-coded extension to allow setting version to known value
-         *
-         * @psalm-suppress PropertyNotSetInConstructor
-         */
-        $event = new class ($this->clock, $versionString) extends ReadyLatestChangelogEvent {
-            private string $releaseDate;
-            private string $version;
-
-            public function __construct(Clock $clock, string $versionString)
-            {
-                $this->releaseDate = $clock->now()->format('Y-m-d');
-                $this->version     = $versionString;
-                // Required as failure methods write to output
-                $this->output = new NullOutput();
-            }
-
-            /**
-             * Overridden as parent uses private property access.
-             */
-            public function version(): string
-            {
-                return $this->version;
-            }
-
-            /**
-             * Overridden as parent uses private property access.
-             */
-            public function releaseDate(): string
-            {
-                return $this->releaseDate;
-            }
-        };
-
-        $event->discoveredConfiguration($this->createKeepAChangelogConfig($changelogFile));
-
-        return $event;
-    }
-
-    private function createKeepAChangelogConfig(string $changelogFile): Config
-    {
-        // Inline extension to allow hard-coding changelog file to what is known.
-        return new class ($changelogFile) extends Config {
-            private string $changelogFile;
-
-            public function __construct(string $changelogFile)
-            {
-                parent::__construct();
-                $this->changelogFile = $changelogFile;
-            }
-
-            public function changelogFile(): string
-            {
-                return $this->changelogFile;
-            }
-        };
     }
 }

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -72,7 +72,7 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
         Assert::stringNotEmpty($changelogFile);
 
-        $releaseNotes->writeChangelogFile($changelogFile);
+        $releaseNotes::writeChangelogFile($changelogFile, $releaseNotes);
 
         $message = sprintf(self::COMMIT_TEMPLATE, $version->fullReleaseName(), self::CHANGELOG_FILE);
         Assert::notEmpty($message);

--- a/src/Github/CreateReleaseText.php
+++ b/src/Github/CreateReleaseText.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Github;
 
+use Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Milestone;
@@ -13,7 +14,6 @@ interface CreateReleaseText
 {
     /**
      * @psalm-param non-empty-string $repositoryDirectory
-     * @psalm-return non-empty-string
      */
     public function __invoke(
         Milestone $milestone,
@@ -21,7 +21,7 @@ interface CreateReleaseText
         SemVerVersion $semVerVersion,
         BranchName $sourceBranch,
         string $repositoryDirectory
-    ): string;
+    ): ChangelogReleaseNotes;
 
     /** @psalm-param non-empty-string $repositoryDirectory */
     public function canCreateReleaseText(

--- a/src/Github/CreateReleaseTextViaKeepAChangelog.php
+++ b/src/Github/CreateReleaseTextViaKeepAChangelog.php
@@ -6,22 +6,60 @@ namespace Laminas\AutomaticReleases\Github;
 
 use InvalidArgumentException;
 use Laminas\AutomaticReleases\Changelog\ChangelogExists;
+use Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Milestone;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use Lcobucci\Clock\Clock;
+use Phly\KeepAChangelog\Common\ChangelogEntry;
 use Phly\KeepAChangelog\Common\ChangelogParser;
 use Phly\KeepAChangelog\Exception\ExceptionInterface;
 use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
+use function count;
+use function explode;
+use function implode;
+use function preg_match;
+use function preg_quote;
+use function preg_replace;
+use function sprintf;
+use function str_replace;
+
 class CreateReleaseTextViaKeepAChangelog implements CreateReleaseText
 {
-    private ChangelogExists $changelogExists;
+    private const DEFAULT_CONTENTS = <<< 'CONTENTS'
+        ### Added
+        
+        - Nothing.
+        
+        ### Changed
+        
+        - Nothing.
+        
+        ### Deprecated
+        
+        - Nothing.
+        
+        ### Removed
+        
+        - Nothing.
+        
+        ### Fixed
+        
+        - Nothing.
+        
+        CONTENTS;
 
-    public function __construct(ChangelogExists $changelogExists)
+
+    private ChangelogExists $changelogExists;
+    private Clock $clock;
+
+    public function __construct(ChangelogExists $changelogExists, Clock $clock)
     {
         $this->changelogExists = $changelogExists;
+        $this->clock           = $clock;
     }
 
     public function __invoke(
@@ -30,16 +68,22 @@ class CreateReleaseTextViaKeepAChangelog implements CreateReleaseText
         SemVerVersion $semVerVersion,
         BranchName $sourceBranch,
         string $repositoryDirectory
-    ): string {
-        $changelog = (new ChangelogParser())
-            ->findChangelogForVersion(
-                $this->fetchChangelogContentsFromBranch($sourceBranch, $repositoryDirectory),
+    ): ChangelogReleaseNotes {
+        $changelogEntry = $this->fetchChangelogEntry(
+            $this->fetchChangelogContentsFromBranch($sourceBranch, $repositoryDirectory),
+            $semVerVersion->fullReleaseName()
+        );
+
+        $contents = $changelogEntry->contents();
+        Assert::stringNotEmpty($contents, 'Detected changelog entry for version, but retrieval failed');
+
+        return new ChangelogReleaseNotes(
+            $this->updateReleaseDate(
+                $this->removeDefaultContents($contents),
                 $semVerVersion->fullReleaseName()
-            );
-
-        Assert::notEmpty($changelog);
-
-        return $changelog;
+            ),
+            $changelogEntry
+        );
     }
 
     public function canCreateReleaseText(
@@ -83,5 +127,79 @@ class CreateReleaseTextViaKeepAChangelog implements CreateReleaseText
         Assert::notEmpty($contents);
 
         return $contents;
+    }
+
+    /**
+     * @psalm-param non-empty-string $changelog
+     * @psalm-param non-empty-string $version
+     * @psalm-return non-empty-string
+     */
+    private function updateReleaseDate(string $changelog, string $version): string
+    {
+        $lines = explode("\n", $changelog);
+        Assert::greaterThan(count($lines), 0);
+
+        $releaseLine = $lines[0];
+        $regex       = sprintf('/^(## (?:%1$s|\[%1$s\])).*$/i', preg_quote($version));
+        $lines[0]    = preg_replace($regex, '$1 - ' . $this->clock->now()->format('Y-m-d'), $releaseLine);
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @psalm-param non-empty-string $changelog
+     * @psalm-return non-empty-string
+     */
+    private function removeDefaultContents(string $changelog): string
+    {
+        $contents = str_replace(self::DEFAULT_CONTENTS, '', $changelog);
+        Assert::notEmpty($contents);
+
+        return $contents;
+    }
+
+    /**
+     * @psalm-param non-empty-string $contents
+     * @psalm-param non-empty-string $version
+     */
+    private function fetchChangelogEntry(string $contents, string $version): ChangelogEntry
+    {
+        $entryContents = [];
+        $entryIndex    = null;
+        $entryLength   = 0;
+        $boundaryRegex = '/^(?:## (?:\d+\.\d+\.\d+|\[\d+\.\d+\.\d+\])|\[.*?\]:\s*\S+)/i';
+        $regex         = sprintf('/^## (?:%1$s|\[%1$s\])/i', preg_quote($version));
+
+        foreach (explode("\n", $contents) as $index => $line) {
+            if ($entryIndex && preg_match($boundaryRegex, $line)) {
+                break;
+            }
+
+            if (preg_match($regex, $line)) {
+                $entryContents[] = $line;
+                $entryIndex      = $index;
+                $entryLength     = 1;
+                continue;
+            }
+
+            if (! $entryIndex) {
+                continue;
+            }
+
+            $entryContents[] = $line;
+            $entryLength    += 1;
+        }
+
+        Assert::integer($entryIndex, 'Could not find entry for version ' . $version . ' in project CHANGELOG.md file');
+
+        $entryContents = implode("\n", $entryContents);
+        Assert::stringNotEmpty($entryContents);
+
+        $entry           = new ChangelogEntry();
+        $entry->contents = $entryContents;
+        $entry->index    = $entryIndex;
+        $entry->length   = $entryLength;
+
+        return $entry;
     }
 }

--- a/src/Github/MergeMultipleReleaseNotes.php
+++ b/src/Github/MergeMultipleReleaseNotes.php
@@ -47,7 +47,6 @@ final class MergeMultipleReleaseNotes implements CreateReleaseText
         );
 
         Assert::isInstanceOf($releaseNotes, ChangelogReleaseNotes::class);
-        Assert::notEmpty($releaseNotes->contents());
 
         return $releaseNotes;
     }

--- a/test/unit/Application/CreateMergeUpPullRequestTest.php
+++ b/test/unit/Application/CreateMergeUpPullRequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Test\Unit\Application;
 
 use Laminas\AutomaticReleases\Application\Command\CreateMergeUpPullRequest;
+use Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes;
 use Laminas\AutomaticReleases\Environment\Variables;
 use Laminas\AutomaticReleases\Git\Fetch;
 use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
@@ -155,13 +156,20 @@ JSON
             ->with(self::equalTo(RepositoryName::fromFullName('foo/bar')), 123)
             ->willReturn($this->milestone);
 
+        /** @psalm-var ChangelogReleaseNotes&MockObject $releaseNotes */
+        $releaseNotes = $this->createMock(ChangelogReleaseNotes::class);
+        $releaseNotes
+            ->expects($this->once())
+            ->method('contents')
+            ->willReturn('text of the changelog');
+
         $this->createReleaseText->method('__invoke')
             ->with(
                 self::equalTo($this->milestone),
                 self::equalTo(RepositoryName::fromFullName('foo/bar')),
                 self::equalTo($this->releaseVersion)
             )
-            ->willReturn('text of the changelog');
+            ->willReturn($releaseNotes);
 
         $this->push->expects(self::once())
             ->method('__invoke')
@@ -216,8 +224,11 @@ JSON
         $this->getMilestone->method('__invoke')
             ->willReturn($this->milestone);
 
+        /** @psalm-var ChangelogReleaseNotes&MockObject $releaseNotes */
+        $releaseNotes = $this->createMock(ChangelogReleaseNotes::class);
+
         $this->createReleaseText->method('__invoke')
-            ->willReturn('text of the changelog');
+            ->willReturn($releaseNotes);
 
         $this->push->expects(self::never())
             ->method('__invoke');

--- a/test/unit/Changelog/ChangelogReleaseNotesTest.php
+++ b/test/unit/Changelog/ChangelogReleaseNotesTest.php
@@ -21,7 +21,7 @@ use function sprintf;
 use function sys_get_temp_dir;
 
 /**
- * @covers ChangelogReleaseNotes
+ * @covers \Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes
  */
 class ChangelogReleaseNotesTest extends TestCase
 {

--- a/test/unit/Changelog/ChangelogReleaseNotesTest.php
+++ b/test/unit/Changelog/ChangelogReleaseNotesTest.php
@@ -20,6 +20,9 @@ use function Safe\tempnam;
 use function sprintf;
 use function sys_get_temp_dir;
 
+/**
+ * @covers ChangelogReleaseNotes
+ */
 class ChangelogReleaseNotesTest extends TestCase
 {
     public function testInitialContentsAreThoseProvidedToConstructor(): void

--- a/test/unit/Changelog/ChangelogReleaseNotesTest.php
+++ b/test/unit/Changelog/ChangelogReleaseNotesTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Changelog;
+
+use Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes;
+use Phly\KeepAChangelog\Common\ChangelogEntry;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+use function array_slice;
+use function explode;
+use function file_get_contents;
+use function file_put_contents;
+use function implode;
+use function Safe\tempnam;
+use function sprintf;
+use function sys_get_temp_dir;
+
+class ChangelogReleaseNotesTest extends TestCase
+{
+    public function testInitialContentsAreThoseProvidedToConstructor(): void
+    {
+        $releaseNotes = new ChangelogReleaseNotes('contents');
+        $this->assertSame('contents', $releaseNotes->contents());
+    }
+
+    public function testDoesNotRequireUpdatingChangelogFileIfNoEntryIsPresent(): void
+    {
+        $releaseNotes = new ChangelogReleaseNotes('contents');
+        $this->assertFalse($releaseNotes->requiresUpdatingChangelogFile());
+    }
+
+    public function testDoesNotRequireUpdatingChangelogFileIfChangelogEntryContentsMatchReleaseNotes(): void
+    {
+        $entry           = new ChangelogEntry();
+        $entry->contents = 'contents';
+        $releaseNotes    = new ChangelogReleaseNotes('contents', $entry);
+        $this->assertFalse($releaseNotes->requiresUpdatingChangelogFile());
+    }
+
+    public function testRequiresUpdatingChangelogFileIfChangelogEntryContentsDoNotMatchReleaseNotes(): void
+    {
+        $entry           = new ChangelogEntry();
+        $entry->contents = 'contents';
+        $releaseNotes    = new ChangelogReleaseNotes('new contents', $entry);
+        $this->assertTrue($releaseNotes->requiresUpdatingChangelogFile());
+    }
+
+    public function testWriteChangelogIsNoOpIfNoUpdatesAreRequired(): void
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'ChangelogReleaseNotes');
+        Assert::stringNotEmpty($filename);
+        file_put_contents($filename, 'Original contents');
+
+        $entry           = new ChangelogEntry();
+        $entry->contents = 'Changelog contents';
+        $releaseNotes    = new ChangelogReleaseNotes('Changelog contents', $entry);
+
+        $releaseNotes->writeChangelogFile($filename);
+
+        $this->assertStringEqualsFile($filename, 'Original contents');
+    }
+
+    public function testWriteChangelogRewritesFileWithNewContents(): void
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'ChangelogReleaseNotes');
+        Assert::stringNotEmpty($filename);
+        file_put_contents($filename, self::CHANGELOG_STUB);
+
+        $requiredString = implode(
+            "\n",
+            array_slice(
+                explode("\n", self::CHANGELOG_STUB),
+                0,
+                4
+            )
+        );
+
+        $contents = sprintf(self::CHANGELOG_ENTRY, '2020-01-01');
+        Assert::stringNotEmpty($contents);
+
+        $entry           = new ChangelogEntry();
+        $entry->contents = sprintf(self::CHANGELOG_ENTRY, 'TBD');
+        $entry->index    = 4;
+        $entry->length   = 22;
+
+        $releaseNotes = new ChangelogReleaseNotes($contents, $entry);
+
+        $releaseNotes->writeChangelogFile($filename);
+
+        $contents = file_get_contents($filename);
+
+        $this->assertStringContainsString($requiredString, $contents);
+        $this->assertStringContainsString($releaseNotes->contents(), $contents);
+    }
+
+    public function testMergeRaisesExceptionIfBothCurrentAndNextInstanceContainChangelogEntries(): void
+    {
+        $entry           = new ChangelogEntry();
+        $entry->contents = 'Some contents';
+
+        $original = new ChangelogReleaseNotes('New contents', $entry);
+        $toMerge  = new ChangelogReleaseNotes('Other contents', $entry);
+
+        $this->expectException(RuntimeException::class);
+        $original->merge($toMerge);
+    }
+
+    public function testMergeAppendsContentsOfNextInstanceWithCurrentAndReturnsNewInstance(): void
+    {
+        $original = new ChangelogReleaseNotes('original contents');
+        $second   = new ChangelogReleaseNotes('secondary contents');
+        $merged   = $original->merge($second);
+
+        $this->assertNotSame($original, $merged);
+        $this->assertNotSame($second, $merged);
+        $this->assertMatchesRegularExpression(
+            '/' . $original->contents() . '.*' . $second->contents() . '/s',
+            $merged->contents()
+        );
+    }
+
+    /**
+     * @psalm-return iterable<
+     *     string,
+     *     array{
+     *         0: ChangelogReleaseNotes,
+     *         1: ChangelogReleaseNotes,
+     *         2: ChangelogEntry,
+     *     }
+     * >
+     */
+    public function releaseNotesProvider(): iterable
+    {
+        $changelogEntry = new ChangelogEntry();
+
+        yield 'original contains entry' => [
+            new ChangelogReleaseNotes('original', $changelogEntry),
+            new ChangelogReleaseNotes('secondary'),
+            $changelogEntry,
+        ];
+
+        yield 'secondary contains entry' => [
+            new ChangelogReleaseNotes('original'),
+            new ChangelogReleaseNotes('secondary', $changelogEntry),
+            $changelogEntry,
+        ];
+    }
+
+    /**
+     * @dataProvider releaseNotesProvider
+     */
+    public function testMergedInstanceContainsChangelogEntryFromTheInstanceThatHadOne(
+        ChangelogReleaseNotes $original,
+        ChangelogReleaseNotes $secondary,
+        ChangelogEntry $expectedEntry
+    ): void {
+        $merged = $original->merge($secondary);
+
+        $r = new ReflectionProperty($merged, 'changelogEntry');
+        $r->setAccessible(true);
+        $this->assertSame($expectedEntry, $r->getValue($merged));
+    }
+
+    private const CHANGELOG_ENTRY = <<< 'ENTRY'
+        ## 1.0.1 - %s
+        
+        ### Added
+        
+        - Nothing.
+        
+        ### Changed
+        
+        - Nothing.
+        
+        ### Deprecated
+        
+        - Nothing.
+        
+        ### Removed
+        
+        - Nothing.
+        
+        ### Fixed
+        
+        - Fixed a bug.
+
+        ENTRY;
+
+    private const CHANGELOG_STUB = <<< 'CHANGELOG'
+        # Changelog
+        
+        All notable changes to this project will be documented in this file, in reverse chronological order by release.
+        
+        ## 1.0.1 - TBD
+        
+        ### Added
+        
+        - Nothing.
+        
+        ### Changed
+        
+        - Nothing.
+        
+        ### Deprecated
+        
+        - Nothing.
+        
+        ### Removed
+        
+        - Nothing.
+        
+        ### Fixed
+        
+        - Fixed a bug.
+
+        CHANGELOG;
+}

--- a/test/unit/Changelog/ChangelogReleaseNotesTest.php
+++ b/test/unit/Changelog/ChangelogReleaseNotesTest.php
@@ -60,7 +60,7 @@ class ChangelogReleaseNotesTest extends TestCase
         $entry->contents = 'Changelog contents';
         $releaseNotes    = new ChangelogReleaseNotes('Changelog contents', $entry);
 
-        $releaseNotes->writeChangelogFile($filename);
+        $releaseNotes::writeChangelogFile($filename, $releaseNotes);
 
         $this->assertStringEqualsFile($filename, 'Original contents');
     }
@@ -90,7 +90,7 @@ class ChangelogReleaseNotesTest extends TestCase
 
         $releaseNotes = new ChangelogReleaseNotes($contents, $entry);
 
-        $releaseNotes->writeChangelogFile($filename);
+        $releaseNotes::writeChangelogFile($filename, $releaseNotes);
 
         $contents = file_get_contents($filename);
 
@@ -163,7 +163,9 @@ class ChangelogReleaseNotesTest extends TestCase
 
         $r = new ReflectionProperty($merged, 'changelogEntry');
         $r->setAccessible(true);
-        $this->assertSame($expectedEntry, $r->getValue($merged));
+
+        // Equals, but not same, as the class stores a clone of the original.
+        $this->assertEquals($expectedEntry, $r->getValue($merged));
     }
 
     private const CHANGELOG_ENTRY = <<< 'ENTRY'

--- a/test/unit/Github/CreateChangelogTextTest.php
+++ b/test/unit/Github/CreateChangelogTextTest.php
@@ -10,12 +10,14 @@ use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Res
 use Laminas\AutomaticReleases\Github\CreateReleaseTextThroughChangelog;
 use Laminas\AutomaticReleases\Github\GenerateChangelog;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class CreateChangelogTextTest extends TestCase
 {
     public function testGeneratedReleaseText(): void
     {
+        /** @psalm-var GenerateChangelog&MockObject $generateChangelog */
         $generateChangelog = $this->createMock(GenerateChangelog::class);
 
         $repositoryName = RepositoryName::fromFullName('laminas/repository-name');
@@ -28,7 +30,7 @@ final class CreateChangelogTextTest extends TestCase
 
         self::assertSame(
             <<<'RELEASE'
-Release [The title](http://example.com/milestone)
+### Release Notes for [The title](http://example.com/milestone)
 
 The description
 
@@ -91,6 +93,7 @@ RELEASE
                     BranchName::fromName('1.0.x'),
                     __DIR__
                 )
+                ->contents()
         );
     }
 

--- a/test/unit/Github/CreateChangelogTextTest.php
+++ b/test/unit/Github/CreateChangelogTextTest.php
@@ -16,6 +16,25 @@ final class CreateChangelogTextTest extends TestCase
 {
     public function testGeneratedReleaseText(): void
     {
+        $generatedReleaseNotes = <<< 'NOTES'
+            -----
+
+            2.12.3
+            ======
+
+            - Total issues resolved: 0
+            - Total pull requests resolved: 1
+            - Total contributors: 1
+
+            -----
+
+            Bug
+            ---
+
+            - [999: Some bug that got fixed](https://www.example.com/issues/999) thanks to @somebody
+
+            NOTES;
+
         $generateChangelog = $this->createMock(GenerateChangelog::class);
 
         $repositoryName = RepositoryName::fromFullName('laminas/repository-name');
@@ -24,18 +43,29 @@ final class CreateChangelogTextTest extends TestCase
         $generateChangelog->expects(self::once())
             ->method('__invoke')
             ->with($repositoryName, $semVerVersion)
-            ->willReturn('Generated changelog');
+            ->willReturn($generatedReleaseNotes);
 
         self::assertSame(
-            <<<'RELEASE'
-### Release Notes for [The title](http://example.com/milestone)
-
-The description
-
-Generated changelog
-
-RELEASE
-            ,
+            <<< 'RELEASE'
+                ### Release Notes for [The title](http://example.com/milestone)
+                
+                The description
+                
+                -----
+                
+                ### 2.12.3
+                
+                - Total issues resolved: 0
+                - Total pull requests resolved: 1
+                - Total contributors: 1
+                
+                -----
+                
+                #### Bug
+                
+                - [999: Some bug that got fixed](https://www.example.com/issues/999) thanks to @somebody
+                
+                RELEASE,
             (new CreateReleaseTextThroughChangelog($generateChangelog))
                 ->__invoke(
                     Milestone::fromPayload([

--- a/test/unit/Github/CreateChangelogTextTest.php
+++ b/test/unit/Github/CreateChangelogTextTest.php
@@ -10,14 +10,12 @@ use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Res
 use Laminas\AutomaticReleases\Github\CreateReleaseTextThroughChangelog;
 use Laminas\AutomaticReleases\Github\GenerateChangelog;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class CreateChangelogTextTest extends TestCase
 {
     public function testGeneratedReleaseText(): void
     {
-        /** @psalm-var GenerateChangelog&MockObject $generateChangelog */
         $generateChangelog = $this->createMock(GenerateChangelog::class);
 
         $repositoryName = RepositoryName::fromFullName('laminas/repository-name');

--- a/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
+++ b/test/unit/Github/CreateReleaseTextViaKeepAChangelogTest.php
@@ -239,5 +239,27 @@ class CreateReleaseTextViaKeepAChangelogTest extends TestCase
         
         - Nothing.
         
+        ## 0.1.0 - 2019-01-01
+        
+        ### Added
+        
+        - Everything.
+        
+        ### Changed
+        
+        - Nothing.
+        
+        ### Deprecated
+        
+        - Nothing.
+        
+        ### Removed
+        
+        - Nothing.
+        
+        ### Fixed
+        
+        - Nothing.
+
         END;
 }

--- a/test/unit/Github/MergeMultipleReleaseNotesTest.php
+++ b/test/unit/Github/MergeMultipleReleaseNotesTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Github;
 
+use Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Milestone;
-use Laminas\AutomaticReleases\Github\ConcatenateMultipleReleaseTexts;
 use Laminas\AutomaticReleases\Github\CreateReleaseText;
+use Laminas\AutomaticReleases\Github\MergeMultipleReleaseNotes;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use function assert;
 use function range;
 
-final class ConcatenateMultipleReleaseTextsTest extends TestCase
+final class MergeMultipleReleaseNotesTest extends TestCase
 {
     private Milestone $milestone;
 
@@ -74,7 +75,7 @@ final class ConcatenateMultipleReleaseTextsTest extends TestCase
             $generators[] = $generator;
         }
 
-        $createReleaseText = new ConcatenateMultipleReleaseTexts($generators);
+        $createReleaseText = new MergeMultipleReleaseNotes($generators);
 
         $this->assertFalse(
             $createReleaseText->canCreateReleaseText(
@@ -134,7 +135,7 @@ final class ConcatenateMultipleReleaseTextsTest extends TestCase
             $generators[] = $generator;
         }
 
-        $createReleaseText = new ConcatenateMultipleReleaseTexts($generators);
+        $createReleaseText = new MergeMultipleReleaseNotes($generators);
 
         $this->assertTrue(
             $createReleaseText->canCreateReleaseText(
@@ -183,7 +184,7 @@ final class ConcatenateMultipleReleaseTextsTest extends TestCase
                             $this->equalTo($this->sourceBranch),
                             $this->equalTo($this->repositoryPath)
                         )
-                        ->willReturn('GENERATOR ' . $index);
+                        ->willReturn(new ChangelogReleaseNotes('GENERATOR ' . $index));
                     break;
                 default:
                     $generator
@@ -206,7 +207,7 @@ final class ConcatenateMultipleReleaseTextsTest extends TestCase
             $generators[] = $generator;
         }
 
-        $createReleaseText = new ConcatenateMultipleReleaseTexts($generators);
+        $createReleaseText = new MergeMultipleReleaseNotes($generators);
 
         $expected = <<< 'END'
             GENERATOR 0
@@ -228,7 +229,7 @@ final class ConcatenateMultipleReleaseTextsTest extends TestCase
                 $this->version,
                 $this->sourceBranch,
                 $this->repositoryPath
-            )
+            )->contents()
         );
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | code, yes; UI and usage, no
| New Feature   | yes and no
| RFC           | yes

### Description

When rolling out automatic-releases to various repositories, we noticed an issue with the workflow for documentation, mainly that our docs-build action only builds on pushes to the "master" branch, we are trying to eliminate. This has meant manually pushing the current release branch to the "master" branch on the repository whenever there are changes.

@Ocramius suggested that we merge documentation changes just like bugfixes: assign them to milestones, and build on release. The objections raised were:

- We would have unchanged packages from one version to the next, as docs are excluded via `.gitattributes`. We decided this was not really an issue; most people are not updating regularly, and a package that introduces zero code changes is generally welcome as it represents no risk.

- We would have empty changelogs and release announcements.

This latter was something I realized we could address in the automatic-releases tooling, as:

- We already generate additional release notes via jwage/changelog-generator.
- The phly/keep-a-changelog tooling does not require that entries are in a specific format unless you want to use its `entry:*` commands; the only requirements are the version headings.

As such, this patch refactors how changelogs are generated for release notes, and then committed back to the repository.

In particular:

- It introduces `Laminas\AutomaticReleases\Changelog\ChangelogReleaseNotes`, which is an entity that composes the changelog contents, and optionally a phly/keep-a-changelog `ChangelogEntry` instance. It has behavior:
  - `requiresUpdatingChangelogFile()` returns true if a `ChangelogEntry` is composed AND its contents differ from those stored in the `ChangelogReleaseNotes` instance.
  - `writeChangelogFile(string $changelogFile)` will write the release notes contents to the specified changelog file, per the metadata in the `ChangelogEntry` instance composed.
  - `merge(ChangelogReleaseNotes $next): ChangelogReleaseNotes` will clone itself and merge `$next` into it, returning the clone.

- I updated `CreateReleaseText` to have it return a `ChangelogReleaseNotes` instance.

- I updated `CreateReleaseTextViaKeepAChangelog` to now mimics how the phly/keep-a-changelog library parses a changelog file when parsing string contents representing a full changelog as pulled from the originating branch, in order to create a `ChangelogEntry` that details where the original is found in the file, and how much space it takes. Additionally, it then sets the date for the version, and checks to see if the contents have changed from the template; if not, it clears them before passing them to the `ChangelogReleaseNotes` instance it creates.

- I updated `CreateReleaseThroughChangelog` to perform some minor markdown formatting changes to better accommodate being injected in a CHANGELOG.md file; it also now returns a `ChangelogReleaseNotes` instance (without a `ChangelogEntry` composed).

- I updated `CommitReleaseChangelog` to accept a `ChangelogReleaseNotes` as the first argument; implementations now use it to actually write the `CHANGELOG.md` file prior to committing and pushing it.

- I renamed `ConcatenateMultipleReleaseTexts` to `MergeMultipleReleaseNotes` to better describe what it now does (it uses the `merge()` operation of returned `ChangelogReleaseNotes` instances, returning the final product).

- I updated the logic of `ReleaseCommand` to generate release text first, then commit it.

## tl;dr

When the "release" command of automatic-releases now runs, it will:

- Always generate release notes using jwage/changelog-generator.
- **IF** a `CHANGELOG.md` file is present, it then:
  - Checks to see if it contains any changes for the target version. If not, it replaces the content with the generated release notes.
  - Otherwise, it appends the content with the generated release notes.

The upshot is that documentation maintainers can:

- Add documentation patches to the appropriate milestone.
- Merge those changes.
- Close the milestone.

and get a release issued, which will then trigger builds for documentation.

## Final note

We will need to use the `ORGANIZATION_ADMIN_TOKEN` for the value of the `GITHUB_TOKEN` on the `Release` step of the workflow in order to trigger the release workflow event, and thus the documentation build.