### PR TITLE
End changelog version entry with empty line

### DIFF
--- a/src/Changelog/ChangelogReleaseNotes.php
+++ b/src/Changelog/ChangelogReleaseNotes.php
@@ -9,6 +9,8 @@ use Phly\KeepAChangelog\Common\ChangelogEntry;
 use RuntimeException;
 use Webmozart\Assert\Assert;
 
+use function rtrim;
+
 /**
  * @psalm-immutable
  */
@@ -33,10 +35,12 @@ class ChangelogReleaseNotes
 
         Assert::notNull($releaseNotes->changelogEntry);
 
+        $changelogEntry = rtrim($releaseNotes->contents, "\n") . "\n\n";
+
         $editor = new ChangelogEditor();
         $editor->update(
             $changelogFile,
-            $releaseNotes->contents,
+            $changelogEntry,
             $releaseNotes->changelogEntry
         );
     }

--- a/test/unit/Changelog/ChangelogReleaseNotesTest.php
+++ b/test/unit/Changelog/ChangelogReleaseNotesTest.php
@@ -98,7 +98,7 @@ class ChangelogReleaseNotesTest extends TestCase
         $contents = file_get_contents($filename);
 
         $this->assertStringContainsString($requiredString, $contents);
-        $this->assertStringContainsString($releaseNotes->contents(), $contents);
+        $this->assertStringContainsString($releaseNotes->contents() . "\n", $contents);
     }
 
     public function testMergeRaisesExceptionIfBothCurrentAndNextInstanceContainChangelogEntries(): void


### PR DESCRIPTION
Append an empty line to the changelog entry when writing it to the changelog file, to ensure there's an empty line above the next version entry.

Fixes #65 