### PR TITLE
Add all required environment variables to `release-on-milestone-close…

### DIFF
--- a/examples/.github/workflows/release-on-milestone-closed.yml
+++ b/examples/.github/workflows/release-on-milestone-closed.yml
@@ -52,6 +52,9 @@ jobs:
           command-name: "laminas:automatic-releases:bump-changelog"
         env:
           "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create new milestones"
         uses: "laminas/automatic-releases@v1"


### PR DESCRIPTION
The documentation/example didn't include all necessary environment variables for one of the CLI commands