### PR TITLE
docs: add note about how GITHUB_TOKEN is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ to your project or organization:
   command, because [changing default branch of a repository currently requires administrative token rights](https://developer.github.com/v3/repos/#update-a-repository).
   You can generate a token from your [personal access tokens page](https://github.com/settings/tokens/new).
 
+The `GITHUB_TOKEN` secret you see in the examples is automatically created for
+you when you enable GitHub Actions. To learn more about how it works, read
+["Authenticating with the GITHUB\_TOKEN"](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
+in the GitHub Docs.
+
 ## Usage
 
 Assuming your project has Github Actions enabled, each time you [**close**](https://developer.github.com/webhooks/event-payloads/#milestone)

--- a/src/Github/CreateReleaseTextThroughChangelog.php
+++ b/src/Github/CreateReleaseTextThroughChangelog.php
@@ -136,7 +136,7 @@ MARKDOWN;
             // We will then remove the current line, as the delimiter is no
             // longer necessary.
             /** @psalm-var "-"|"=" $delimiter */
-            $delimiter = $matches['delim']{0};
+            $delimiter = $matches['delim'][0];
             /** @psalm-var non-empty-string $heading */
             $heading         = strtr($delimiter, ['-' => '####', '=' => '###']);
             $lines[$i - 1]   = $heading . ' ' . $previousLine;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR updates the README to include a note about the `GIT_TOKEN` shown in the examples, with a link to more information about how this environment variable is injected when using GitHub Actions.

Also included is a small change to convert the use of deprecated array dereferencing syntax to the updated, acceptable syntax.
