### PR TITLE
Sign commits, as well as tags

### DIFF
--- a/src/Application/Command/BumpChangelogForReleaseBranch.php
+++ b/src/Application/Command/BumpChangelogForReleaseBranch.php
@@ -64,7 +64,8 @@ final class BumpChangelogForReleaseBranch extends Command
             BumpAndCommitChangelogVersion::BUMP_PATCH,
             $repositoryPath,
             $releaseVersion,
-            $releaseBranch
+            $releaseBranch,
+            $this->environment->signingSecretKey()
         );
 
         return 0;

--- a/src/Application/Command/ReleaseCommand.php
+++ b/src/Application/Command/ReleaseCommand.php
@@ -92,7 +92,13 @@ final class ReleaseCommand extends Command
             $repositoryPath
         );
 
-        ($this->commitChangelog)($changelogReleaseNotes, $repositoryPath, $releaseVersion, $releaseBranch);
+        ($this->commitChangelog)(
+            $changelogReleaseNotes,
+            $repositoryPath,
+            $releaseVersion,
+            $releaseBranch,
+            $this->environment->signingSecretKey()
+        );
 
         $tagName = $releaseVersion->fullReleaseName();
 

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -81,7 +81,8 @@ final class SwitchDefaultBranchToNextMinor extends Command
                 BumpAndCommitChangelogVersion::BUMP_MINOR,
                 $repositoryPath,
                 $releaseVersion,
-                $nextDefaultBranch
+                $nextDefaultBranch,
+                $this->variables->signingSecretKey()
             );
         }
 

--- a/src/Changelog/BumpAndCommitChangelogVersion.php
+++ b/src/Changelog/BumpAndCommitChangelogVersion.php
@@ -6,6 +6,7 @@ namespace Laminas\AutomaticReleases\Changelog;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 
 interface BumpAndCommitChangelogVersion
 {
@@ -20,6 +21,7 @@ interface BumpAndCommitChangelogVersion
         string $bumpType,
         string $repositoryDirectory,
         SemVerVersion $version,
-        BranchName $sourceBranch
+        BranchName $sourceBranch,
+        SecretKeyId $keyId
     ): void;
 }

--- a/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
+++ b/src/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelog.php
@@ -9,6 +9,7 @@ use Laminas\AutomaticReleases\Git\CommitFile;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use Phly\KeepAChangelog\Bump\ChangelogBump;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
@@ -49,7 +50,8 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
         string $bumpType,
         string $repositoryDirectory,
         SemVerVersion $version,
-        BranchName $sourceBranch
+        BranchName $sourceBranch,
+        SecretKeyId $keyId
     ): void {
         if (! ($this->changelogExists)($sourceBranch, $repositoryDirectory)) {
             // No changelog
@@ -75,7 +77,8 @@ class BumpAndCommitChangelogVersionViaKeepAChangelog implements BumpAndCommitCha
             $repositoryDirectory,
             $sourceBranch,
             self::CHANGELOG_FILE,
-            $message
+            $message,
+            $keyId
         );
 
         ($this->push)($repositoryDirectory, $sourceBranch->name());

--- a/src/Changelog/CommitReleaseChangelog.php
+++ b/src/Changelog/CommitReleaseChangelog.php
@@ -6,6 +6,7 @@ namespace Laminas\AutomaticReleases\Changelog;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 
 interface CommitReleaseChangelog
 {
@@ -16,6 +17,7 @@ interface CommitReleaseChangelog
         ChangelogReleaseNotes $releaseNotes,
         string $repositoryDirectory,
         SemVerVersion $version,
-        BranchName $sourceBranch
+        BranchName $sourceBranch,
+        SecretKeyId $keyId
     ): void;
 }

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -9,6 +9,7 @@ use Laminas\AutomaticReleases\Git\CommitFile;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
 
@@ -51,7 +52,8 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
         ChangelogReleaseNotes $releaseNotes,
         string $repositoryDirectory,
         SemVerVersion $version,
-        BranchName $sourceBranch
+        BranchName $sourceBranch,
+        SecretKeyId $keyId
     ): void {
         if (! $releaseNotes->requiresUpdatingChangelogFile()) {
             // Nothing to commit
@@ -81,7 +83,8 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
             $repositoryDirectory,
             $sourceBranch,
             self::CHANGELOG_FILE,
-            $message
+            $message,
+            $keyId
         );
 
         ($this->push)($repositoryDirectory, $sourceBranch->name());

--- a/src/Git/CommitFile.php
+++ b/src/Git/CommitFile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 
 interface CommitFile
 {
@@ -17,6 +18,7 @@ interface CommitFile
         string $repositoryDirectory,
         BranchName $sourceBranch,
         string $filename,
-        string $commitMessage
+        string $commitMessage,
+        SecretKeyId $keyId
     ): void;
 }

--- a/src/Git/CommitFileViaConsole.php
+++ b/src/Git/CommitFileViaConsole.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use Symfony\Component\Process\Process;
 use Webmozart\Assert\Assert;
 
@@ -17,7 +18,8 @@ final class CommitFileViaConsole implements CommitFile
         string $repositoryDirectory,
         BranchName $sourceBranch,
         string $filename,
-        string $commitMessage
+        string $commitMessage,
+        SecretKeyId $keyId
     ): void {
         $this->assertWeAreOnBranch($sourceBranch, $repositoryDirectory, $filename);
 
@@ -25,7 +27,7 @@ final class CommitFileViaConsole implements CommitFile
             ->mustRun();
 
         (new Process(
-            ['git', 'commit', '-m', $commitMessage],
+            ['git', 'commit', '-m', $commitMessage, '--gpg-sign=' . $keyId->id()],
             $repositoryDirectory
         ))->mustRun();
     }

--- a/test/unit/Application/BumpChangelogForReleaseBranchTest.php
+++ b/test/unit/Application/BumpChangelogForReleaseBranchTest.php
@@ -14,11 +14,13 @@ use Laminas\AutomaticReleases\Git\Value\MergeTargetCandidateBranches;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
 use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
+use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
+use function file_get_contents;
 use function mkdir;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -67,6 +69,11 @@ class BumpChangelogForReleaseBranchTest extends TestCase
                 "action": "closed"
             }
             JSON);
+
+        $key = (new ImportGpgKeyFromStringViaTemporaryFile())
+            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
+
+        $this->environment->method('signingSecretKey')->willReturn($key);
     }
 
     public function testWillBumpChangelogVersion(): void

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -17,12 +17,14 @@ use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranch;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
 use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
+use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
+use function file_get_contents;
 use function mkdir;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -82,6 +84,11 @@ final class SwitchDefaultBranchToNextMinorTest extends TestCase
 }
 JSON
         );
+
+        $key = (new ImportGpgKeyFromStringViaTemporaryFile())
+            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
+
+        $this->variables->method('signingSecretKey')->willReturn($key);
 
         $this->variables->method('githubToken')
             ->willReturn('github-auth-token');

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -13,6 +13,8 @@ use Laminas\AutomaticReleases\Git\CommitFile;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -38,6 +40,7 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
     /** @var LoggerInterface&MockObject */
     private $logger;
     private BumpAndCommitChangelogVersionViaKeepAChangelog $bumpAndCommitChangelog;
+    private SecretKeyId $key;
 
     protected function setUp(): void
     {
@@ -52,6 +55,9 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
             $this->push,
             $this->logger
         );
+
+        $this->key = (new ImportGpgKeyFromStringViaTemporaryFile())
+            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
     }
 
     public function testReturnsEarlyWhenNoChangelogFilePresent(): void
@@ -74,7 +80,8 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
                 BumpAndCommitChangelogVersion::BUMP_PATCH,
                 $repoDir,
                 $version,
-                $sourceBranch
+                $sourceBranch,
+                $this->key
             )
         );
     }
@@ -173,7 +180,8 @@ class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
                 $bumpType,
                 $repoDir,
                 $version,
-                $sourceBranch
+                $sourceBranch,
+                $this->key
             )
         );
 

--- a/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/ReleaseChangelogViaKeepAChangelogTest.php
@@ -13,6 +13,8 @@ use Laminas\AutomaticReleases\Git\CommitFile;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
+use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
+use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use Lcobucci\Clock\Clock;
 use Lcobucci\Clock\FrozenClock;
 use Phly\KeepAChangelog\Common\ChangelogEntry;
@@ -49,6 +51,7 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
     private LoggerInterface $logger;
 
     private CommitReleaseChangelogViaKeepAChangelog $releaseChangelog;
+    private SecretKeyId $key;
 
     protected function setUp(): void
     {
@@ -65,6 +68,9 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
             $this->push,
             $this->logger
         );
+
+        $this->key = (new ImportGpgKeyFromStringViaTemporaryFile())
+            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
     }
 
     public function testNoOpWhenChangelogFileDoesNotExist(): void
@@ -95,7 +101,8 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
                 $releaseNotes,
                 __DIR__,
                 SemVerVersion::fromMilestoneName('0.99.99'),
-                BranchName::fromName('0.99.x')
+                BranchName::fromName('0.99.x'),
+                $this->key
             )
         );
     }
@@ -133,7 +140,8 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
                 $releaseNotes,
                 $checkout,
                 SemVerVersion::fromMilestoneName('1.0.0'),
-                $branch
+                $branch,
+                $this->key
             )
         );
     }
@@ -209,7 +217,8 @@ class ReleaseChangelogViaKeepAChangelogTest extends TestCase
                 $releaseNotes,
                 $checkout,
                 SemVerVersion::fromMilestoneName('1.0.0'),
-                BranchName::fromName('1.0.x')
+                BranchName::fromName('1.0.x'),
+                $this->key
             )
         );
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Currently, automatic-releases signs Git tags using the signing key but not commits. This PR provides support for signing commits, as well.

This is a BC break because some of the interfaces have changed to require `Laminas\AutomaticReleases\Gpg\SecretKeyId`. This is not an optional parameter. As such, this change might need to wait until 2.0.0, unless the risk is deemed acceptable for 1.7.0 or 1.8.0.