### PR TITLE
Replace bash wrapper for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,4 @@ ADD src /app/src
 
 RUN composer install -a --no-dev
 
-ADD entrypoint.sh /app/entrypoint.sh
-
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/app/bin/console.php"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-/app/bin/console.php $@


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Replace bash wrapper for entrypoint, invoke console.php directly.

Solves two issues:
- Update entrypoint for argument quoting so that word splitting does not lose spaces in arguments (see details in https://github.com/laminas/automatic-releases/pull/98)
- Release memory from shell process. Besides releasing resources (memory), this is very important in docker containers so that signals get routed properly to PID=1.
