### PR TITLE
Fix workflow trigger to include all branches and tags

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -3,10 +3,10 @@
 name: "Check Coding Standards"
 
 on:
+  create:
   pull_request:
   push:
     branches:
-      - "master"
 
 jobs:
   coding-standards:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -3,7 +3,10 @@
 name: "Mutation tests"
 
 on:
+  create:
   pull_request:
+  push:
+    branches:
 
 jobs:
   mutation-tests:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,10 +3,10 @@
 name: "PHPUnit tests"
 
 on:
+  create:
   pull_request:
   push:
     branches:
-      - "master"
 
 jobs:
   phpunit:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -3,10 +3,10 @@
 name: "Static Analysis by Psalm"
 
 on:
+  create:
   pull_request:
   push:
     branches:
-      - "master"
 
 jobs:
   static-analysis-psalm:


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fixes the CI build triggers:

- Use versioned branches (e.g. `1.9.x`) instead of `master`
- Run CI on branch and tag [creation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#create). The CI for the current [1.9.x](https://github.com/laminas/automatic-releases/actions?query=workflow%3A%22PHPUnit+tests%22+branch%3A1.9.x) branch did never run. 