### PR TITLE
Reduce docker image size (and build time)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,4 +18,4 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Docker Build"
-        run: "docker build ."
+        run: "DOCKER_BUILDKIT=1 docker build ."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:2 AS composer
 
-FROM ubuntu:20.04
+FROM php:8.0-alpine
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
@@ -15,21 +15,10 @@ LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
 
 WORKDIR /app
 
-RUN apt update \
-    && apt install -y software-properties-common \
-    && add-apt-repository -y ppa:ondrej/php \
-    && apt install -y \
-        git \
-        gnupg \
-        libzip-dev \
-        zip \
-        php8.0-cli \
-        php8.0-curl \
-        php8.0-mbstring \
-        php8.0-readline \
-        php8.0-xml \
-        php8.0-zip \
-    && apt clean
+RUN apk add --no-cache git gnupg libzip \
+    && apk add --no-cache --virtual .build-deps libzip-dev \
+    && docker-php-ext-install zip \
+    && apk del .build-deps
 
 ADD composer.json /app/composer.json
 ADD composer.lock /app/composer.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --no-autoloader
 COPY bin /app/bin/
 COPY src /app/src/
 
-RUN composer install -a --no-dev
+RUN composer dump-autoload -a --no-dev
 
 ENTRYPOINT ["/app/bin/console.php"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,15 @@ RUN apk add --no-cache git gnupg libzip \
     && docker-php-ext-install zip \
     && apk del .build-deps
 
-ADD composer.json /app/composer.json
-ADD composer.lock /app/composer.lock
+COPY composer.* /app/
 
 RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --no-autoloader
 
 # @TODO https://github.com/laminas/automatic-releases/issues/8 we skip `.git` for now, as it isn't available in the build environment
 # @TODO https://github.com/laminas/automatic-releases/issues/9 we skip `.git` for now, as it isn't available in the build environment
 #ADD .git /app/.git
-ADD bin /app/bin
-ADD src /app/src
+COPY bin /app/bin/
+COPY src /app/src/
 
 RUN composer install -a --no-dev
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This improves the build process of the docker image.

When the base images are already downloaded, it takes about 15s to build the image using BuildKit - previously it was taking 1m19s.
The image size has also been drastically reduced, it's 122Mb - previously was 390Mb.