### PR TITLE
Fix mutation test flow for branches/tags

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -28,6 +28,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Fetch github.base_ref (for diffing)"
+        if: ${{ github.base_ref != '' }}
         run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
 
       - name: "Install PHP"
@@ -59,11 +60,19 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest"
 
       - name: "Infection"
+        if: ${{ github.base_ref != '' }}
         run: |
           vendor/bin/roave-infection-static-analysis-plugin \
             --ignore-msi-with-no-mutations \
             --git-diff-filter=AM \
             --git-diff-base=origin/${{ github.base_ref }}
+        env:
+          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+
+      - name: "Infection"
+        if: ${{ github.base_ref == '' }}
+        run: vendor/bin/roave-infection-static-analysis-plugin --ignore-msi-with-no-mutations
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      |no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

The variable `github.base_ref` isn't set when running the flow against branches/tags, which is leading the build to fail.

This creates conditional executions to make sure the build isn't accidentally broken any more.

---

Example of successful build on a branch (after this change): https://github.com/lcobucci/automatic-releases/runs/1982270612