### PR TITLE
Modify action to build and consume container

### DIFF
--- a/.github/actions/automatic-releases/action.yml
+++ b/.github/actions/automatic-releases/action.yml
@@ -15,6 +15,6 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/laminas/automatic-releases:1'
+  image: '../../../Dockerfile'
   args:
     - ${{ inputs.command-name }}

--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "./"
+        uses: "./.github/actions/automatic-releases/"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -27,7 +27,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create Merge-Up Pull Request"
-        uses: "./"
+        uses: "./.github/actions/automatic-releases/"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:
@@ -37,7 +37,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create and/or Switch to new Release Branch"
-        uses: "./"
+        uses: "./.github/actions/automatic-releases/"
         with:
           command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
         env:
@@ -47,7 +47,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Bump Changelog Version On Originating Release Branch"
-        uses: "./"
+        uses: "./.github/actions/automatic-releases/"
         with:
           command-name: "laminas:automatic-releases:bump-changelog"
         env:
@@ -57,7 +57,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create new milestones"
-        uses: "./"
+        uses: "./.github/actions/automatic-releases/"
         with:
           command-name: "laminas:automatic-releases:create-milestones"
         env:

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -5,10 +5,8 @@ on:
     types: [published]
 
 jobs:
-  tags:
+  release-container:
     runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.tags.outputs.tags }}
     steps:
       - name: Compile tag list
         id: tags
@@ -18,12 +16,7 @@ jobs:
           MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
           PATCH="${PREFIX}:${TAG}"
-          echo "::set-output name=tags::${MAJOR}%0A${MINOR}%0A${PATCH}"
-
-  release-container:
-    runs-on: ubuntu-latest
-    needs: [tags]
-    steps:
+          echo "::set-output name=tags::[\"${MAJOR}\",\"${MINOR}\",\"${PATCH}\"]"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup QEMU
@@ -43,5 +36,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ needs.tags.outputs.tags }}
-
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), "\n") }}

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Compile tag list
         id: tags
         run: |
-          TAG=${GITHUB_REF/refs\/tags\//}
+          TAG=${GITHUB_REF#refs/tags/}
           PREFIX=ghcr.io/laminas/automatic-releases
           MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -36,4 +36,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ join(fromJSON(steps.tags.outputs.tags), "\n") }}
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ",") }}

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -17,18 +17,23 @@ jobs:
           MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
           PATCH="${PREFIX}:${TAG}"
           echo "::set-output name=tags::[\"${MAJOR}\",\"${MINOR}\",\"${PATCH}\"]"
+
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ secrets.AUTOMATIC_RELEASES_CONTAINER_USERNAME }}
           password: ${{ secrets.AUTOMATIC_RELEASES_CONTAINER_PAT }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.CONTAINER_USERNAME }}
-          password: ${{ secrets.CONTAINER_PAT }}
+          username: ${{ secrets.AUTOMATIC_RELEASES_CONTAINER_USERNAME }}
+          password: ${{ secrets.AUTOMATIC_RELEASES_CONTAINER_PAT }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -1,0 +1,47 @@
+name: Build and push containers
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.tags.outputs.tags }}
+    steps:
+      - name: Compile tag list
+        id: tags
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          PREFIX=ghcr.io/laminas/automatic-releases
+          MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
+          MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
+          PATCH="${PREFIX}:${TAG}"
+          echo "::set-output name=tags::${MAJOR}%0A${MINOR}%0A${PATCH}"
+
+  release-container:
+    runs-on: ubuntu-latest
+    needs: [tags]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.CONTAINER_USERNAME }}
+          password: ${{ secrets.CONTAINER_PAT }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ needs.tags.outputs.tags }}
+


### PR DESCRIPTION
To speed things up further, we can build and release the actual container on release publication, and then have the action itself consume the image instead of the Dockerfile.

Additionally, we can force the release process to use the latest set of changes by defining a local GHA that uses the Dockerfile instead.
I've proven this works at https://github.com/weierophinney/test-local-action/, where I observed that the build happens relative to the checkout directory, and not to where the action is defined.

This will require defining two secrets in this repository:

- CONTAINER_USERNAME (username on ghcr.io)
- CONTAINER_PAT (personal authentication token with container write permissions)

Once setup, this should automatically build and push tags for the docker image, and the action will use the image to do its work.
