### PR TITLE
Use ' instead of "in workflow expression

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -41,4 +41,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ",") }}
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}


### PR DESCRIPTION
An error in the workflow expression caused the workflow to no longer build.  Working workflows in laminas-ci-matrix-action and laminas-continuous-integration-action use `'` isntead of `"` in these expressions.
