### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ gpg --homedir gpg-tmp --output private.key --armor --export-secret-subkeys "<Sub
 Finally, remove the ephemeral directory:
 
 ```bash
-rm --rf gpg-tmp
+rm -rf gpg-tmp
 ```
 
 You will now need to export your master public key with the new subkey public key to the file `public.key`:


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

Fix (very tiny) typo in README.md : `rm --rf` should be `rm -rf`.