### PR TITLE
replace `thecodingmachine/safe`, `webmozart/assert`, and `symfony/process` by `azjezz/psl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"
 
 WORKDIR /app
 
-RUN apk add --no-cache git gnupg libzip \
+RUN apk add --no-cache git gnupg libzip icu-dev \
     && apk add --no-cache --virtual .build-deps libzip-dev \
     && docker-php-ext-install zip \
+    && docker-php-ext-install bcmath \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl \
     && apk del .build-deps
 
 COPY composer.* /app/

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
     },
     "require": {
         "php": "^8.0.0",
-        "ocramius/package-versions": "^2.3.0",
+        "azjezz/psl": "^1.7.1",
         "jwage/changelog-generator": "^1.3.0",
         "laminas/laminas-diactoros": "^2.5.0",
         "lcobucci/clock": "^2.0.0",
         "monolog/monolog": "^2.2.0",
+        "ocramius/package-versions": "^2.3.0",
         "phly/keep-a-changelog": "^2.11.0",
         "php-http/curl-client": "^2.2.0",
         "php-http/discovery": "^1.13.0",
@@ -22,10 +23,7 @@
         "psr/http-client": "^1.0.1",
         "psr/http-message": "^1.0.1",
         "psr/log": "^1.1.3",
-        "symfony/console": "^5.2.3",
-        "symfony/process": "^5.2.2",
-        "thecodingmachine/safe": "^1.3.3",
-        "webmozart/assert": "^1.9.1"
+        "symfony/console": "^5.2.3"
     },
     "autoload-dev": {
         "psr-4": {
@@ -34,11 +32,12 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^8.2.0",
+        "php-standard-library/psalm-plugin": "^1.1.1",
         "phpunit/phpunit": "^9.5.0",
         "psalm/plugin-phpunit": "^0.15.1",
         "roave/infection-static-analysis-plugin": "^1.7",
         "squizlabs/php_codesniffer": "^3.5.8",
-        "vimeo/psalm": "^4.3.2"
+        "vimeo/psalm": "^4.7.2"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,65 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2735cbde3c60b0422fe2d77626617cb9",
+    "content-hash": "22b6d4d7deb1bdc24159062e936dfd9f",
     "packages": [
+        {
+            "name": "azjezz/psl",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/azjezz/psl.git",
+                "reference": "edf5ba8c9bc5cdca5aff79f38e5effd23621b163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/azjezz/psl/zipball/edf5ba8c9bc5cdca5aff79f38e5effd23621b163",
+                "reference": "edf5ba8c9bc5cdca5aff79f38e5effd23621b163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-sodium": "*",
+                "php": "^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psl\\Integration\\Psalm\\Plugin"
+                },
+                "thanks": {
+                    "name": "hhvm/hsl",
+                    "url": "https://github.com/hhvm/hsl"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psl\\Integration\\": "integration"
+                },
+                "files": [
+                    "src/bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/azjezz/psl/issues",
+                "source": "https://github.com/azjezz/psl/tree/1.7.1"
+            },
+            "time": "2021-05-19T11:55:09+00:00"
+        },
         {
             "name": "clue/stream-filter",
             "version": "v1.5.0",
@@ -2695,68 +2752,6 @@
             "time": "2021-01-07T16:49:33+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v5.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
-                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.15"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v5.2.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-01-27T10:15:41+00:00"
-        },
-        {
             "name": "symfony/service-contracts",
             "version": "v2.2.0",
             "source": {
@@ -2917,198 +2912,6 @@
                 }
             ],
             "time": "2021-01-25T15:14:59+00:00"
-        },
-        {
-            "name": "thecodingmachine/safe",
-            "version": "v1.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
-                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12",
-                "squizlabs/php_codesniffer": "^3.2",
-                "thecodingmachine/phpstan-strict-rules": "^0.12"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "deprecated/",
-                        "generated/"
-                    ]
-                },
-                "files": [
-                    "deprecated/apc.php",
-                    "deprecated/libevent.php",
-                    "deprecated/mssql.php",
-                    "deprecated/stats.php",
-                    "lib/special_cases.php",
-                    "generated/apache.php",
-                    "generated/apcu.php",
-                    "generated/array.php",
-                    "generated/bzip2.php",
-                    "generated/calendar.php",
-                    "generated/classobj.php",
-                    "generated/com.php",
-                    "generated/cubrid.php",
-                    "generated/curl.php",
-                    "generated/datetime.php",
-                    "generated/dir.php",
-                    "generated/eio.php",
-                    "generated/errorfunc.php",
-                    "generated/exec.php",
-                    "generated/fileinfo.php",
-                    "generated/filesystem.php",
-                    "generated/filter.php",
-                    "generated/fpm.php",
-                    "generated/ftp.php",
-                    "generated/funchand.php",
-                    "generated/gmp.php",
-                    "generated/gnupg.php",
-                    "generated/hash.php",
-                    "generated/ibase.php",
-                    "generated/ibmDb2.php",
-                    "generated/iconv.php",
-                    "generated/image.php",
-                    "generated/imap.php",
-                    "generated/info.php",
-                    "generated/ingres-ii.php",
-                    "generated/inotify.php",
-                    "generated/json.php",
-                    "generated/ldap.php",
-                    "generated/libxml.php",
-                    "generated/lzf.php",
-                    "generated/mailparse.php",
-                    "generated/mbstring.php",
-                    "generated/misc.php",
-                    "generated/msql.php",
-                    "generated/mysql.php",
-                    "generated/mysqli.php",
-                    "generated/mysqlndMs.php",
-                    "generated/mysqlndQc.php",
-                    "generated/network.php",
-                    "generated/oci8.php",
-                    "generated/opcache.php",
-                    "generated/openssl.php",
-                    "generated/outcontrol.php",
-                    "generated/password.php",
-                    "generated/pcntl.php",
-                    "generated/pcre.php",
-                    "generated/pdf.php",
-                    "generated/pgsql.php",
-                    "generated/posix.php",
-                    "generated/ps.php",
-                    "generated/pspell.php",
-                    "generated/readline.php",
-                    "generated/rpminfo.php",
-                    "generated/rrd.php",
-                    "generated/sem.php",
-                    "generated/session.php",
-                    "generated/shmop.php",
-                    "generated/simplexml.php",
-                    "generated/sockets.php",
-                    "generated/sodium.php",
-                    "generated/solr.php",
-                    "generated/spl.php",
-                    "generated/sqlsrv.php",
-                    "generated/ssdeep.php",
-                    "generated/ssh2.php",
-                    "generated/stream.php",
-                    "generated/strings.php",
-                    "generated/swoole.php",
-                    "generated/uodbc.php",
-                    "generated/uopz.php",
-                    "generated/url.php",
-                    "generated/var.php",
-                    "generated/xdiff.php",
-                    "generated/xml.php",
-                    "generated/xmlrpc.php",
-                    "generated/yaml.php",
-                    "generated/yaz.php",
-                    "generated/zip.php",
-                    "generated/zlib.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v1.3.3"
-            },
-            "time": "2020-10-28T17:51:34+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
-            },
-            "time": "2020-07-08T17:02:28+00:00"
         }
     ],
     "packages-dev": [
@@ -4480,6 +4283,57 @@
                 "source": "https://github.com/phar-io/version/tree/3.0.4"
             },
             "time": "2020-12-13T23:18:30+00:00"
+        },
+        {
+            "name": "php-standard-library/psalm-plugin",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-standard-library/psalm-plugin.git",
+                "reference": "adab2a073c3d66384da7c700293d43f7f9d43e99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-standard-library/psalm-plugin/zipball/adab2a073c3d66384da7c700293d43f7f9d43e99",
+                "reference": "adab2a073c3d66384da7c700293d43f7f9d43e99",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "vimeo/psalm": "^4.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "roave/security-advisories": "dev-master",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psl\\Psalm\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psl\\Psalm\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "Psalm plugin for the PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/php-standard-library/psalm-plugin/issues",
+                "source": "https://github.com/php-standard-library/psalm-plugin/tree/1.1.1"
+            },
+            "time": "2021-04-11T12:56:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6623,6 +6477,207 @@
             "time": "2021-01-28T22:06:19+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v5.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
+                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.3.0-BETA1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-08T10:27:02+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
+                "reference": "a8ab0876305a4cdaef31b2350fcb9811b5608dbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "deprecated/",
+                        "generated/"
+                    ]
+                },
+                "files": [
+                    "deprecated/apc.php",
+                    "deprecated/libevent.php",
+                    "deprecated/mssql.php",
+                    "deprecated/stats.php",
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/ingres-ii.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/msql.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/mysqlndMs.php",
+                    "generated/mysqlndQc.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/password.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pdf.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/simplexml.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v1.3.3"
+            },
+            "time": "2020-10-28T17:51:34+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -6674,24 +6729,24 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.4.1",
+            "version": "4.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9fd7a7d885b3a216cff8dec9d8c21a132f275224"
+                "reference": "83a0325c0a95c0ab531d6b90c877068b464377b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9fd7a7d885b3a216cff8dec9d8c21a132f275224",
-                "reference": "9fd7a7d885b3a216cff8dec9d8c21a132f275224",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/83a0325c0a95c0ab531d6b90c877068b464377b5",
+                "reference": "83a0325c0a95c0ab531d6b90c877068b464377b5",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2.1",
+                "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
@@ -6700,8 +6755,8 @@
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
-                "felixfbecker/language-server-protocol": "^1.4",
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.10.1",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
@@ -6713,10 +6768,10 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
-                "amphp/amp": "^2.4.2",
                 "bamarni/composer-bin-plugin": "^1.2",
                 "brianium/paratest": "^4.0||^6.0",
                 "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpdocumentor/reflection-docblock": "^5",
                 "phpmyadmin/sql-parser": "5.1.0||dev-master",
                 "phpspec/prophecy": ">=1.9.0",
@@ -6725,6 +6780,7 @@
                 "slevomat/coding-standard": "^6.3.11",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
@@ -6772,9 +6828,62 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.4.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.7.2"
             },
-            "time": "2021-01-14T21:44:29+00:00"
+            "time": "2021-05-01T20:56:25+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -12,6 +12,6 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 75,
-    "minCoveredMsi": 77
+    "minMsi": 97,
+    "minCoveredMsi": 100
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -29,5 +29,6 @@
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        <pluginClass class="Psl\Psalm\Plugin"/>
     </plugins>
 </psalm>

--- a/src/Application/Command/BumpChangelogForReleaseBranch.php
+++ b/src/Application/Command/BumpChangelogForReleaseBranch.php
@@ -9,12 +9,12 @@ use Laminas\AutomaticReleases\Environment\Variables;
 use Laminas\AutomaticReleases\Git\Fetch;
 use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Psl;
+use Psl\Filesystem;
+use Psl\Str;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\Assert\Assert;
-
-use function sprintf;
 
 final class BumpChangelogForReleaseBranch extends Command
 {
@@ -47,7 +47,7 @@ final class BumpChangelogForReleaseBranch extends Command
         $repositoryCloneUri   = $repositoryName->uriWithTokenAuthentication($this->environment->githubToken());
         $repositoryPath       = $this->environment->githubWorkspacePath();
 
-        Assert::directory($repositoryPath . '/.git');
+        Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
         ($this->fetch)($repositoryCloneUri, $repositoryPath);
 
@@ -55,10 +55,7 @@ final class BumpChangelogForReleaseBranch extends Command
         $releaseVersion  = $milestoneClosedEvent->version();
         $releaseBranch   = $mergeCandidates->targetBranchFor($releaseVersion);
 
-        Assert::notNull(
-            $releaseBranch,
-            sprintf('No valid release branch found for version %s', $releaseVersion->fullReleaseName())
-        );
+        Psl\invariant($releaseBranch !== null, Str\format('No valid release branch found for version %s', $releaseVersion->fullReleaseName()));
 
         ($this->bumpChangelogVersion)(
             BumpAndCommitChangelogVersion::BUMP_PATCH,

--- a/src/Application/Command/CreateMergeUpPullRequest.php
+++ b/src/Application/Command/CreateMergeUpPullRequest.php
@@ -13,13 +13,13 @@ use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetGithubMilestone;
 use Laminas\AutomaticReleases\Github\Api\V3\CreatePullRequest;
 use Laminas\AutomaticReleases\Github\CreateReleaseText;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Psl;
+use Psl\Filesystem;
+use Psl\SecureRandom;
+use Psl\Str;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\Assert\Assert;
-
-use function sprintf;
-use function uniqid;
 
 final class CreateMergeUpPullRequest extends Command
 {
@@ -59,7 +59,7 @@ final class CreateMergeUpPullRequest extends Command
         $event          = $this->loadGithubEvent->__invoke();
         $repositoryPath = $this->variables->githubWorkspacePath();
 
-        Assert::directory($repositoryPath . '/.git');
+        Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
         $this->fetch->__invoke(
             $event->repository()
@@ -74,7 +74,7 @@ final class CreateMergeUpPullRequest extends Command
         $mergeUpTarget  = $mergeCandidates->branchToMergeUp($releaseVersion);
 
         if ($mergeUpTarget === null) {
-            $output->writeln(sprintf(
+            $output->writeln(Str\format(
                 'No merge-up candidate for release %s - skipping pull request creation',
                 $releaseVersion->fullReleaseName()
             ));
@@ -82,16 +82,14 @@ final class CreateMergeUpPullRequest extends Command
             return 0;
         }
 
-        Assert::notNull(
-            $releaseBranch,
-            sprintf('No valid release branch found for version %s', $releaseVersion->fullReleaseName())
-        );
+        Psl\invariant($releaseBranch !== null, Str\format('No valid release branch found for version %s', $releaseVersion->fullReleaseName()));
 
         $mergeUpBranch = BranchName::fromName(
             $releaseBranch->name()
             . '-merge-up-into-'
             . $mergeUpTarget->name()
-            . uniqid('_', true) // This is to ensure that a new merge-up pull request is created even if one already exists
+            . '_'
+            . SecureRandom\string(8) // This is to ensure that a new merge-up pull request is created even if one already exists
         );
 
         $releaseNotes = $this->createReleaseText->__invoke(

--- a/src/Application/Command/CreateMilestones.php
+++ b/src/Application/Command/CreateMilestones.php
@@ -41,14 +41,12 @@ final class CreateMilestones extends Command
         return 0;
     }
 
-    private function createMilestoneIfNotExists(RepositoryName $repositoryName, SemVerVersion $version): bool
+    private function createMilestoneIfNotExists(RepositoryName $repositoryName, SemVerVersion $version): void
     {
         try {
             ($this->createMilestone)($repositoryName, $version);
-        } catch (CreateMilestoneFailed $e) {
-            return false;
+        } catch (CreateMilestoneFailed) {
+            return;
         }
-
-        return true;
     }
 }

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -11,10 +11,11 @@ use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranches;
 use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Github\Api\V3\SetDefaultBranch;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEvent;
+use Psl;
+use Psl\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\Assert\Assert;
 
 final class SwitchDefaultBranchToNextMinor extends Command
 {
@@ -51,7 +52,7 @@ final class SwitchDefaultBranchToNextMinor extends Command
         $event          = $this->loadGithubEvent->__invoke();
         $repositoryPath = $this->variables->githubWorkspacePath();
 
-        Assert::directory($repositoryPath . '/.git');
+        Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
         $this->fetch->__invoke(
             $event->repository()

--- a/src/Changelog/ChangelogExistsViaConsole.php
+++ b/src/Changelog/ChangelogExistsViaConsole.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Changelog;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
-use Symfony\Component\Process\Process;
+use Psl\Shell;
 
 class ChangelogExistsViaConsole implements ChangelogExists
 {
@@ -16,9 +16,12 @@ class ChangelogExistsViaConsole implements ChangelogExists
         BranchName $sourceBranch,
         string $repositoryDirectory
     ): bool {
-        $process = new Process(['git', 'show', 'origin/' . $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
-        $process->run();
+        try {
+            Shell\execute('git', ['show', 'origin/' . $sourceBranch->name() . ':CHANGELOG.md'], $repositoryDirectory);
 
-        return $process->isSuccessful();
+            return true;
+        } catch (Shell\Exception\FailedExecutionException) {
+            return false;
+        }
     }
 }

--- a/src/Changelog/ChangelogReleaseNotes.php
+++ b/src/Changelog/ChangelogReleaseNotes.php
@@ -6,10 +6,9 @@ namespace Laminas\AutomaticReleases\Changelog;
 
 use Phly\KeepAChangelog\Common\ChangelogEditor;
 use Phly\KeepAChangelog\Common\ChangelogEntry;
+use Psl;
+use Psl\Str;
 use RuntimeException;
-use Webmozart\Assert\Assert;
-
-use function rtrim;
 
 /**
  * @psalm-immutable
@@ -33,9 +32,9 @@ class ChangelogReleaseNotes
             return;
         }
 
-        Assert::notNull($releaseNotes->changelogEntry);
+        Psl\invariant($releaseNotes->changelogEntry !== null, 'Release does not contain a changelog entry.');
 
-        $changelogEntry = rtrim($releaseNotes->contents, "\n") . "\n\n";
+        $changelogEntry = Str\trim_right($releaseNotes->contents, "\n") . "\n\n";
 
         $editor = new ChangelogEditor();
         $editor->update(

--- a/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
+++ b/src/Changelog/CommitReleaseChangelogViaKeepAChangelog.php
@@ -10,10 +10,9 @@ use Laminas\AutomaticReleases\Git\Push;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
+use Psl\Str;
+use Psl\Type;
 use Psr\Log\LoggerInterface;
-use Webmozart\Assert\Assert;
-
-use function sprintf;
 
 final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChangelog
 {
@@ -71,13 +70,13 @@ final class CommitReleaseChangelogViaKeepAChangelog implements CommitReleaseChan
 
         ($this->checkoutBranch)($repositoryDirectory, $sourceBranch);
 
-        $changelogFile = sprintf('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE);
-        Assert::stringNotEmpty($changelogFile);
+        $changelogFile = Type\non_empty_string()
+            ->assert(Str\format('%s/%s', $repositoryDirectory, self::CHANGELOG_FILE));
 
         $releaseNotes::writeChangelogFile($changelogFile, $releaseNotes);
 
-        $message = sprintf(self::COMMIT_TEMPLATE, $version->fullReleaseName(), self::CHANGELOG_FILE);
-        Assert::notEmpty($message);
+        $message = Type\non_empty_string()
+            ->assert(Str\format(self::COMMIT_TEMPLATE, $version->fullReleaseName(), self::CHANGELOG_FILE));
 
         ($this->commitFile)(
             $repositoryDirectory,

--- a/src/Git/CheckoutBranchViaConsole.php
+++ b/src/Git/CheckoutBranchViaConsole.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
-use Symfony\Component\Process\Process;
+use Psl\Shell;
 
 class CheckoutBranchViaConsole implements CheckoutBranch
 {
@@ -13,7 +13,6 @@ class CheckoutBranchViaConsole implements CheckoutBranch
         string $repositoryDirectory,
         BranchName $branchName
     ): void {
-        (new Process(['git', 'switch', $branchName->name()], $repositoryDirectory))
-            ->mustRun();
+        Shell\execute('git', ['switch', $branchName->name()], $repositoryDirectory);
     }
 }

--- a/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
+++ b/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
+use Psl\Shell;
 use Psr\Http\Message\UriInterface;
-use Symfony\Component\Process\Process;
 
 final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetch
 {
@@ -21,19 +21,14 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
         UriInterface $repositoryUri,
         string $repositoryRootDirectory
     ): void {
-        (new Process(['git', 'remote', 'rm', 'origin'], $repositoryRootDirectory))
-            ->run();
+        try {
+            Shell\execute('git', ['remote', 'rm', 'origin'], $repositoryRootDirectory);
+        } catch (Shell\Exception\FailedExecutionException) {
+        }
 
-        (new Process(['git', 'remote', 'add', 'origin', $repositoryUri->__toString()], $repositoryRootDirectory))
-            ->mustRun();
-
-        (new Process(['git', 'fetch', 'origin'], $repositoryRootDirectory))
-            ->mustRun();
-
-        (new Process(['git', 'config', 'user.email', $this->variables->gitAuthorEmail()], $repositoryRootDirectory))
-            ->mustRun();
-
-        (new Process(['git', 'config', 'user.name', $this->variables->gitAuthorName()], $repositoryRootDirectory))
-            ->mustRun();
+        Shell\execute('git', ['remote', 'add', 'origin', $repositoryUri->__toString()], $repositoryRootDirectory);
+        Shell\execute('git', ['fetch', 'origin'], $repositoryRootDirectory);
+        Shell\execute('git', ['config', 'user.email', $this->variables->gitAuthorEmail()], $repositoryRootDirectory);
+        Shell\execute('git', ['config', 'user.name', $this->variables->gitAuthorName()], $repositoryRootDirectory);
     }
 }

--- a/src/Git/GetMergeTargetCandidateBranchesFromRemoteBranches.php
+++ b/src/Git/GetMergeTargetCandidateBranchesFromRemoteBranches.php
@@ -6,36 +6,28 @@ namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\MergeTargetCandidateBranches;
-use Symfony\Component\Process\Process;
-
-use function array_filter;
-use function array_map;
-use function assert;
-use function explode;
-use function is_string;
-use function Safe\preg_replace;
-use function trim;
+use Psl\Regex;
+use Psl\Shell;
+use Psl\Str;
+use Psl\Vec;
 
 final class GetMergeTargetCandidateBranchesFromRemoteBranches implements GetMergeTargetCandidateBranches
 {
     public function __invoke(string $repositoryRootDirectory): MergeTargetCandidateBranches
     {
-        $branches = array_filter(explode(
+        $branches = Vec\filter(Str\split(
+            Shell\execute('git', ['branch', '-r'], $repositoryRootDirectory),
             "\n",
-            (new Process(['git', 'branch', '-r'], $repositoryRootDirectory))
-                ->mustRun()
-                ->getOutput()
         ));
 
-        return MergeTargetCandidateBranches::fromAllBranches(...array_map(static function (string $branch): BranchName {
-            $sanitizedBranch = preg_replace(
+        return MergeTargetCandidateBranches::fromAllBranches(...Vec\map($branches, static function (string $branch): BranchName {
+            $sanitizedBranch = Regex\replace(
+                Str\trim($branch, "* \t\n\r\0\x0B"),
                 '~^(?:remotes/)?origin/~',
-                '',
-                trim($branch, "* \t\n\r\0\x0B")
+                ''
             );
-            assert(is_string($sanitizedBranch));
 
             return BranchName::fromName($sanitizedBranch);
-        }, $branches));
+        }));
     }
 }

--- a/src/Git/PushViaConsole.php
+++ b/src/Git/PushViaConsole.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git;
 
-use Symfony\Component\Process\Process;
-
-use function uniqid;
+use Psl\SecureRandom;
+use Psl\Shell;
 
 final class PushViaConsole implements Push
 {
@@ -16,21 +15,15 @@ final class PushViaConsole implements Push
         ?string $alias = null
     ): void {
         if ($alias === null) {
-            (new Process(['git', 'push', 'origin', $symbol], $repositoryDirectory))
-                ->mustRun();
+            Shell\execute('git', ['push', 'origin', $symbol], $repositoryDirectory);
 
             return;
         }
 
-        $localTemporaryBranch = uniqid('temporary-branch', true);
+        $localTemporaryBranch = 'temporary-branch' . SecureRandom\string(8);
 
-        (new Process(['git', 'branch', $localTemporaryBranch, $symbol], $repositoryDirectory))
-            ->mustRun();
-
-        (new Process(['git', 'push', 'origin', $localTemporaryBranch . ':' . $alias], $repositoryDirectory))
-            ->mustRun();
-
-        (new Process(['git', 'branch', '-D', $localTemporaryBranch], $repositoryDirectory))
-            ->mustRun();
+        Shell\execute('git', ['branch', $localTemporaryBranch, $symbol], $repositoryDirectory);
+        Shell\execute('git', ['push', 'origin', $localTemporaryBranch . ':' . $alias], $repositoryDirectory);
+        Shell\execute('git', ['branch', '-D', $localTemporaryBranch], $repositoryDirectory);
     }
 }

--- a/src/Git/Value/SemVerVersion.php
+++ b/src/Git/Value/SemVerVersion.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git\Value;
 
-use Webmozart\Assert\Assert;
-
-use function Safe\preg_match;
+use Psl;
+use Psl\Regex;
 
 /** @psalm-immutable */
 final class SemVerVersion
@@ -24,16 +23,15 @@ final class SemVerVersion
 
     /**
      * @psalm-pure
-     * @psalm-suppress ImpureFunctionCall the {@see \Safe\preg_match()} API is pure by design
+     * @psalm-suppress ImpureFunctionCall {@see https://github.com/azjezz/psl/issues/130}
      */
     public static function fromMilestoneName(string $name): self
     {
-        Assert::notEmpty($name);
-        Assert::regex($name, '/^(v)?\\d+\\.\\d+\\.\\d+$/');
+        Psl\invariant(Regex\matches($name, '/^(v)?\\d+\\.\\d+\\.\\d+$/'), 'Milestone name is malformed.');
 
-        preg_match('/(\\d+)\\.(\\d+)\\.(\\d+)/', $name, $matches);
+        $matches = Regex\first_match($name, '/(\\d+)\\.(\\d+)\\.(\\d+)/', Regex\capture_groups([1, 2, 3]));
 
-        Assert::isList($matches);
+        Psl\invariant($matches !== null, 'Expected milestone name to match.');
 
         return new self((int) $matches[1], (int) $matches[2], (int) $matches[3]);
     }

--- a/src/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/Author.php
+++ b/src/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/Author.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response;
 
 use Laminas\Diactoros\Uri;
+use Psl\Type;
 use Psr\Http\Message\UriInterface;
-use Webmozart\Assert\Assert;
 
 final class Author
 {
@@ -24,11 +24,10 @@ final class Author
     /** @param array<string, mixed> $payload */
     public static function fromPayload(array $payload): self
     {
-        Assert::isMap($payload);
-        Assert::keyExists($payload, 'login');
-        Assert::keyExists($payload, 'url');
-        Assert::stringNotEmpty($payload['login']);
-        Assert::stringNotEmpty($payload['url']);
+        $payload = Type\shape([
+            'login' => Type\non_empty_string(),
+            'url' => Type\non_empty_string(),
+        ])->coerce($payload);
 
         return new self($payload['login'], new Uri($payload['url']));
     }

--- a/src/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/Label.php
+++ b/src/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/Label.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response;
 
 use Laminas\Diactoros\Uri;
+use Psl;
+use Psl\Regex;
+use Psl\Type;
 use Psr\Http\Message\UriInterface;
-use Webmozart\Assert\Assert;
 
 /** @psalm-immutable */
 final class Label
@@ -37,17 +39,18 @@ final class Label
      *
      * @psalm-pure
      *
-     * @psalm-suppress ImpureMethodCall the {@see UriInterface} API is pure by design
+     * @psalm-suppress ImpureMethodCall     {@see https://github.com/azjezz/psl/issues/130}
+     * @psalm-suppress ImpureFunctionCall   {@see https://github.com/azjezz/psl/issues/130}
      */
     public static function fromPayload(array $payload): self
     {
-        Assert::keyExists($payload, 'color');
-        Assert::keyExists($payload, 'name');
-        Assert::keyExists($payload, 'url');
-        Assert::stringNotEmpty($payload['color']);
-        Assert::regex($payload['color'], '/^[0-9a-f]{6}$/i');
-        Assert::stringNotEmpty($payload['name']);
-        Assert::stringNotEmpty($payload['url']);
+        $payload = Type\shape([
+            'color' => Type\non_empty_string(),
+            'name' => Type\non_empty_string(),
+            'url' => Type\non_empty_string(),
+        ])->coerce($payload);
+
+        Psl\invariant(Regex\matches($payload['color'], '/^[0-9a-f]{6}$/i'), 'Malformed label color.');
 
         return new self(
             $payload['color'],

--- a/src/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequests.php
+++ b/src/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequests.php
@@ -7,7 +7,7 @@ namespace Laminas\AutomaticReleases\Github\Api\GraphQL\Query;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Milestone;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\RunQuery;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
-use Webmozart\Assert\Assert;
+use Psl\Type;
 
 final class GetMilestoneFirst100IssuesAndPullRequests implements GetGithubMilestone
 {
@@ -86,10 +86,11 @@ GRAPHQL;
             ]
         );
 
-        Assert::keyExists($queryResult, 'repository');
-        Assert::isMap($queryResult['repository']);
-        Assert::keyExists($queryResult['repository'], 'milestone');
-        Assert::isMap($queryResult['repository']['milestone']);
+        $queryResult = Type\shape([
+            'repository' => Type\shape([
+                'milestone' => Type\dict(Type\string(), Type\mixed()),
+            ]),
+        ])->coerce($queryResult);
 
         return Milestone::fromPayload($queryResult['repository']['milestone']);
     }

--- a/src/Github/Api/GraphQL/RunGraphQLQuery.php
+++ b/src/Github/Api/GraphQL/RunGraphQLQuery.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Github\Api\GraphQL;
 
+use Psl\Json;
+use Psl\Type;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use Webmozart\Assert\Assert;
-
-use function Safe\json_decode;
-use function Safe\json_encode;
 
 final class RunGraphQLQuery implements RunQuery
 {
@@ -45,7 +43,7 @@ final class RunGraphQLQuery implements RunQuery
 
         $request
             ->getBody()
-            ->write(json_encode([
+            ->write(Json\encode([
                 'query'     => $query,
                 'variables' => $variables,
             ]));
@@ -56,15 +54,10 @@ final class RunGraphQLQuery implements RunQuery
             ->getBody()
             ->__toString();
 
-        Assert::same($response->getStatusCode(), 200);
+        Type\literal_scalar(200)->assert($response->getStatusCode());
 
-        $responseData = json_decode($responseBody, true);
-
-        Assert::isMap($responseData);
-        Assert::keyNotExists($responseData, 'errors');
-        Assert::keyExists($responseData, 'data');
-        Assert::isArray($responseData['data']);
-
-        return $responseData['data'];
+        return Json\typed($responseBody, Type\shape([
+            'data' => Type\dict(Type\string(), Type\mixed()),
+        ]))['data'];
     }
 }

--- a/src/Github/Event/Factory/LoadCurrentGithubEventFromGithubActionPath.php
+++ b/src/Github/Event/Factory/LoadCurrentGithubEventFromGithubActionPath.php
@@ -6,9 +6,7 @@ namespace Laminas\AutomaticReleases\Github\Event\Factory;
 
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
 use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
-use Webmozart\Assert\Assert;
-
-use function Safe\file_get_contents;
+use Psl\Filesystem;
 
 final class LoadCurrentGithubEventFromGithubActionPath implements LoadCurrentGithubEvent
 {
@@ -23,8 +21,6 @@ final class LoadCurrentGithubEventFromGithubActionPath implements LoadCurrentGit
     {
         $path = $this->variables->githubEventPath();
 
-        Assert::fileExists($path);
-
-        return MilestoneClosedEvent::fromEventJson(file_get_contents($path));
+        return MilestoneClosedEvent::fromEventJson(Filesystem\read_file($path));
     }
 }

--- a/src/Gpg/SecretKeyId.php
+++ b/src/Gpg/SecretKeyId.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Gpg;
 
-use Webmozart\Assert\Assert;
+use Psl;
+use Psl\Regex;
+use Psl\Str;
 
 /** @psalm-immutable */
 final class SecretKeyId
@@ -21,8 +23,8 @@ final class SecretKeyId
     /** @psalm-pure */
     public static function fromBase16String(string $keyId): self
     {
-        Assert::notEmpty($keyId);
-        Assert::regex($keyId, '/^[A-F0-9]+$/i');
+        Psl\invariant(! Str\is_empty($keyId), 'Expected a non-empty key id.');
+        Psl\invariant(Regex\matches($keyId, '/^[A-F0-9]+$/i'), 'Key id is malformed.');
 
         return new self($keyId);
     }

--- a/test/unit/Application/BumpChangelogForReleaseBranchTest.php
+++ b/test/unit/Application/BumpChangelogForReleaseBranchTest.php
@@ -33,7 +33,7 @@ class BumpChangelogForReleaseBranchTest extends TestCase
     /** @var GetMergeTargetCandidateBranches&MockObject */
     private GetMergeTargetCandidateBranches $getMergeTargets;
     /** @var BumpAndCommitChangelogVersion&MockObject */
-    private MockObject | BumpAndCommitChangelogVersion $bumpChangelogVersion;
+    private BumpAndCommitChangelogVersion $bumpChangelogVersion;
     private MilestoneClosedEvent $event;
     private BumpChangelogForReleaseBranch $command;
 

--- a/test/unit/Application/BumpChangelogForReleaseBranchTest.php
+++ b/test/unit/Application/BumpChangelogForReleaseBranchTest.php
@@ -17,27 +17,23 @@ use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psl\Env;
+use Psl\Filesystem;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
-
-use function file_get_contents;
-use function mkdir;
-use function sys_get_temp_dir;
-use function tempnam;
-use function unlink;
 
 class BumpChangelogForReleaseBranchTest extends TestCase
 {
     /** @var Variables&MockObject */
-    private $environment;
+    private Variables $environment;
     /** @var LoadCurrentGithubEvent&MockObject */
-    private $loadEvent;
+    private LoadCurrentGithubEvent $loadEvent;
     /** @var Fetch&MockObject */
-    private $fetch;
+    private Fetch $fetch;
     /** @var GetMergeTargetCandidateBranches&MockObject */
-    private $getMergeTargets;
+    private GetMergeTargetCandidateBranches $getMergeTargets;
     /** @var BumpAndCommitChangelogVersion&MockObject */
-    private $bumpChangelogVersion;
+    private MockObject | BumpAndCommitChangelogVersion $bumpChangelogVersion;
     private MilestoneClosedEvent $event;
     private BumpChangelogForReleaseBranch $command;
 
@@ -71,18 +67,18 @@ class BumpChangelogForReleaseBranchTest extends TestCase
             JSON);
 
         $key = (new ImportGpgKeyFromStringViaTemporaryFile())
-            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
+            ->__invoke(Filesystem\read_file(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
 
         $this->environment->method('signingSecretKey')->willReturn($key);
     }
 
     public function testWillBumpChangelogVersion(): void
     {
-        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
 
-        unlink($workspace);
-        mkdir($workspace);
-        mkdir($workspace . '/.git');
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
 
         $branches = MergeTargetCandidateBranches::fromAllBranches(
             BranchName::fromName('1.1.x'),

--- a/test/unit/Application/ReleaseCommandTest.php
+++ b/test/unit/Application/ReleaseCommandTest.php
@@ -25,17 +25,14 @@ use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psl\Env;
+use Psl\Filesystem;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-use function mkdir;
-use function sys_get_temp_dir;
-use function tempnam;
-use function unlink;
-
 final class ReleaseCommandTest extends TestCase
 {
-    /** @var Variables&MockObject */
+    /** @var MockObject&Variables */
     private Variables $variables;
     /** @var LoadCurrentGithubEvent&MockObject */
     private LoadCurrentGithubEvent $loadEvent;
@@ -51,7 +48,7 @@ final class ReleaseCommandTest extends TestCase
     private CreateReleaseText $createReleaseText;
     /** @var CreateTag&MockObject */
     private CreateTag $createTag;
-    /** @var Push&MockObject */
+    /** @var MockObject&Push */
     private Push $push;
     /** @var CreateRelease&MockObject */
     private CreateRelease $createRelease;
@@ -122,7 +119,7 @@ JSON
             'pullRequests' => [
                 'nodes' => [],
             ],
-            'url'          => 'http://example.com/milestone',
+            'url'          => 'https://example.com/milestone',
         ]);
 
         $this->releaseVersion = SemVerVersion::fromMilestoneName('1.2.3');
@@ -141,11 +138,11 @@ JSON
 
     public function testWillRelease(): void
     {
-        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
 
-        unlink($workspace);
-        mkdir($workspace);
-        mkdir($workspace . '/.git');
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
 
         $this->variables->method('githubWorkspacePath')
             ->willReturn($workspace);
@@ -168,7 +165,7 @@ JSON
         /** @psalm-var ChangelogReleaseNotes&MockObject $releaseNotes */
         $releaseNotes = $this->createMock(ChangelogReleaseNotes::class);
         $releaseNotes
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('contents')
             ->willReturn('text of the changelog');
 

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -20,19 +20,15 @@ use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psl\Env;
+use Psl\Filesystem;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
-use function file_get_contents;
-use function mkdir;
-use function sys_get_temp_dir;
-use function tempnam;
-use function unlink;
-
 final class SwitchDefaultBranchToNextMinorTest extends TestCase
 {
-    /** @var Variables&MockObject */
+    /** @var MockObject&Variables */
     private Variables $variables;
     /** @var LoadCurrentGithubEvent&MockObject */
     private LoadCurrentGithubEvent $loadEvent;
@@ -40,9 +36,9 @@ final class SwitchDefaultBranchToNextMinorTest extends TestCase
     private Fetch $fetch;
     /** @var GetMergeTargetCandidateBranches&MockObject */
     private GetMergeTargetCandidateBranches $getMergeTargets;
-    /** @var Push&MockObject */
+    /** @var MockObject&Push */
     private Push $push;
-    /** @var SetDefaultBranch&MockObject */
+    /** @var MockObject&SetDefaultBranch */
     private SetDefaultBranch $setDefaultBranch;
     /** @var BumpAndCommitChangelogVersion&MockObject */
     private BumpAndCommitChangelogVersion $bumpChangelogVersion;
@@ -86,7 +82,7 @@ JSON
         );
 
         $key = (new ImportGpgKeyFromStringViaTemporaryFile())
-            ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
+            ->__invoke(Filesystem\read_file(__DIR__ . '/../../asset/dummy-gpg-key.asc'));
 
         $this->variables->method('signingSecretKey')->willReturn($key);
 
@@ -101,11 +97,11 @@ JSON
 
     public function testWillSwitchToExistingNewestDefaultBranch(): void
     {
-        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
 
-        unlink($workspace);
-        mkdir($workspace);
-        mkdir($workspace . '/.git');
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
 
         $this->variables->method('githubWorkspacePath')
             ->willReturn($workspace);
@@ -144,11 +140,11 @@ JSON
 
     public function testWillSwitchToNewlyCreatedDefaultBranchWhenNoNewerReleaseBranchExists(): void
     {
-        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
 
-        unlink($workspace);
-        mkdir($workspace);
-        mkdir($workspace . '/.git');
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
 
         $this->variables->method('githubWorkspacePath')
             ->willReturn($workspace);
@@ -193,11 +189,11 @@ JSON
 
     public function testWillNotSwitchDefaultBranchIfNoBranchesExist(): void
     {
-        $workspace = tempnam(sys_get_temp_dir(), 'workspace');
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
 
-        unlink($workspace);
-        mkdir($workspace);
-        mkdir($workspace . '/.git');
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
 
         $this->variables->method('githubWorkspacePath')
             ->willReturn($workspace);

--- a/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
+++ b/test/unit/Changelog/BumpAndCommitChangelogVersionViaKeepAChangelogTest.php
@@ -27,11 +27,11 @@ use Psr\Log\LoggerInterface;
 class BumpAndCommitChangelogVersionViaKeepAChangelogTest extends TestCase
 {
     /** @var CheckoutBranch&MockObject */
-    private MockObject | CheckoutBranch $checkoutBranch;
+    private CheckoutBranch $checkoutBranch;
     /** @var CommitFile&MockObject */
-    private MockObject | CommitFile $commitFile;
+    private CommitFile $commitFile;
     /** @var Push&MockObject */
-    private MockObject | Push $push;
+    private Push $push;
     /** @var LoggerInterface&MockObject */
     private LoggerInterface $logger;
     private BumpAndCommitChangelogVersionViaKeepAChangelog $bumpAndCommitChangelog;

--- a/test/unit/Git/Value/BranchNameTest.php
+++ b/test/unit/Git/Value/BranchNameTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Git\Value;
 
-use InvalidArgumentException;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use PHPUnit\Framework\TestCase;
+use Psl\Type\Exception\AssertException;
 
 final class BranchNameTest extends TestCase
 {
@@ -39,7 +39,7 @@ final class BranchNameTest extends TestCase
 
     public function testDisallowsEmptyBranchName(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(AssertException::class);
 
         BranchName::fromName('');
     }

--- a/test/unit/Git/Value/SemVerVersionTest.php
+++ b/test/unit/Git/Value/SemVerVersionTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Git\Value;
 
-use InvalidArgumentException;
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use PHPUnit\Framework\TestCase;
+use Psl\Exception\InvariantViolationException;
 
 final class SemVerVersionTest extends TestCase
 {
@@ -47,7 +47,7 @@ final class SemVerVersionTest extends TestCase
      */
     public function testRejectsInvalidReleaseStrings(string $invalid): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvariantViolationException::class);
 
         SemVerVersion::fromMilestoneName($invalid);
     }

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/AuthorTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/AuthorTest.php
@@ -13,10 +13,10 @@ final class AuthorTest extends TestCase
     {
         $author = Author::fromPayload([
             'login' => 'Magoo',
-            'url'   => 'http://example.com/',
+            'url'   => 'https://example.com/',
         ]);
 
         self::assertSame('Magoo', $author->name());
-        self::assertSame('http://example.com/', $author->url()->__toString());
+        self::assertSame('https://example.com/', $author->url()->__toString());
     }
 }

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/IssueOrPullRequestTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/IssueOrPullRequestTest.php
@@ -18,21 +18,21 @@ final class IssueOrPullRequestTest extends TestCase
             'title'  => 'Yadda',
             'author' => [
                 'login' => 'Magoo',
-                'url'   => 'http://example.com/author',
+                'url'   => 'https://example.com/author',
             ],
-            'url'    => 'http://example.com/issue',
+            'url'    => 'https://example.com/issue',
             'closed' => true,
             'labels' => [
                 'nodes' => [
                     [
                         'name'  => 'BC Break',
                         'color' => 'abcabc',
-                        'url'   => 'http://example.com/bc-break',
+                        'url'   => 'https://example.com/bc-break',
                     ],
                     [
                         'name'  => 'Question',
                         'color' => 'defdef',
-                        'url'   => 'http://example.com/question',
+                        'url'   => 'https://example.com/question',
                     ],
                 ],
             ],
@@ -40,12 +40,12 @@ final class IssueOrPullRequestTest extends TestCase
 
         self::assertSame(123, $issue->number());
         self::assertTrue($issue->closed());
-        self::assertSame('http://example.com/issue', $issue->url()->__toString());
+        self::assertSame('https://example.com/issue', $issue->url()->__toString());
         self::assertSame('Yadda', $issue->title());
         self::assertEquals(
             Author::fromPayload([
                 'login' => 'Magoo',
-                'url'   => 'http://example.com/author',
+                'url'   => 'https://example.com/author',
             ]),
             $issue->author()
         );
@@ -54,12 +54,12 @@ final class IssueOrPullRequestTest extends TestCase
                 Label::fromPayload([
                     'name'  => 'BC Break',
                     'color' => 'abcabc',
-                    'url'   => 'http://example.com/bc-break',
+                    'url'   => 'https://example.com/bc-break',
                 ]),
                 Label::fromPayload([
                     'name'  => 'Question',
                     'color' => 'defdef',
-                    'url'   => 'http://example.com/question',
+                    'url'   => 'https://example.com/question',
                 ]),
             ],
             $issue->labels()

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/LabelTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/LabelTest.php
@@ -6,6 +6,8 @@ namespace Laminas\AutomaticReleases\Test\Unit\Github\Api\GraphQL\Query\GetMilest
 
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneChangelog\Response\Label;
 use PHPUnit\Framework\TestCase;
+use Psl\Exception\InvariantViolationException;
+use Psl\Type\Exception\CoercionException;
 
 final class LabelTest extends TestCase
 {
@@ -14,11 +16,88 @@ final class LabelTest extends TestCase
         $label = Label::fromPayload([
             'name'  => 'BC Break',
             'color' => 'abcabc',
-            'url'   => 'http://example.com/',
+            'url'   => 'https://example.com/',
         ]);
 
         self::assertSame('BC Break', $label->name());
         self::assertSame('abcabc', $label->colour());
-        self::assertSame('http://example.com/', $label->url()->__toString());
+        self::assertSame('https://example.com/', $label->url()->__toString());
+    }
+
+    public function testMalformedLabel(): void
+    {
+        $this->expectException(InvariantViolationException::class);
+        $this->expectExceptionMessage('Malformed label color.');
+
+        Label::fromPayload([
+            'name'  => 'BC Break',
+            'color' => 'hello-world',
+            'url'   => 'https://example.com/',
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @dataProvider provideInvalidPayload
+     */
+    public function testInvalidPayload(array $payload): void
+    {
+        $this->expectException(CoercionException::class);
+
+        Label::fromPayload($payload);
+    }
+
+    /**
+     * @return iterable<int, list<array<string, mixed>>>
+     */
+    public function provideInvalidPayload(): iterable
+    {
+        yield [
+            [
+                'name'  => ['a', 'b'],
+                'color' => 'ffffff',
+                'url'   => 'https://example.com/',
+            ],
+        ];
+
+        yield [
+            [
+                'name'  => '',
+                'color' => 'ffffff',
+                'url'   => 'https://example.com/',
+            ],
+        ];
+
+        yield [
+            [
+                'name'  => 'BC Break',
+                'color' => '',
+                'url'   => 'https://example.com/',
+            ],
+        ];
+
+        yield [
+            [
+                'name'  => 'BC Break',
+                'color' => 'ffffff',
+                'url'   => '',
+            ],
+        ];
+
+        yield [
+            [
+                'name'  => 'BC Break',
+                'color' => 'ffffff',
+            ],
+        ];
+
+        yield [
+            ['name' => 'BC Break'],
+        ];
+
+        yield [
+            ['username' => 'BC Break'],
+        ];
     }
 }

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/MilestoneTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneChangelog/Response/MilestoneTest.php
@@ -24,9 +24,9 @@ final class MilestoneTest extends TestCase
                         'title'  => 'Issue',
                         'author' => [
                             'login' => 'Magoo',
-                            'url'   => 'http://example.com/author',
+                            'url'   => 'https://example.com/author',
                         ],
-                        'url'    => 'http://example.com/issue',
+                        'url'    => 'https://example.com/issue',
                         'closed' => true,
                         'labels' => [
                             'nodes' => [],
@@ -41,9 +41,9 @@ final class MilestoneTest extends TestCase
                         'title'  => 'PR',
                         'author' => [
                             'login' => 'Magoo',
-                            'url'   => 'http://example.com/author',
+                            'url'   => 'https://example.com/author',
                         ],
-                        'url'    => 'http://example.com/issue',
+                        'url'    => 'https://example.com/issue',
                         'merged' => true,
                         'closed' => false,
                         'labels' => [
@@ -52,7 +52,7 @@ final class MilestoneTest extends TestCase
                     ],
                 ],
             ],
-            'url'          => 'http://example.com/milestone',
+            'url'          => 'https://example.com/milestone',
         ]);
 
         self::assertEquals(
@@ -62,9 +62,9 @@ final class MilestoneTest extends TestCase
                     'title'  => 'Issue',
                     'author' => [
                         'login' => 'Magoo',
-                        'url'   => 'http://example.com/author',
+                        'url'   => 'https://example.com/author',
                     ],
-                    'url'    => 'http://example.com/issue',
+                    'url'    => 'https://example.com/issue',
                     'closed' => true,
                     'labels' => [
                         'nodes' => [],
@@ -75,9 +75,9 @@ final class MilestoneTest extends TestCase
                     'title'  => 'PR',
                     'author' => [
                         'login' => 'Magoo',
-                        'url'   => 'http://example.com/author',
+                        'url'   => 'https://example.com/author',
                     ],
-                    'url'    => 'http://example.com/issue',
+                    'url'    => 'https://example.com/issue',
                     'merged' => true,
                     'closed' => false,
                     'labels' => [
@@ -90,9 +90,11 @@ final class MilestoneTest extends TestCase
 
         self::assertSame(123, $milestone->number());
         self::assertTrue($milestone->closed());
-        self::assertSame('http://example.com/milestone', $milestone->url()->__toString());
+        self::assertSame('https://example.com/milestone', $milestone->url()->__toString());
         self::assertSame('The title', $milestone->title());
         self::assertSame('The description', $milestone->description());
+
+        /** @psalm-suppress UnusedMethodCall */
         $milestone->assertAllIssuesAreClosed();
     }
 }

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequestsTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequestsTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class GetMilestoneFirst100IssuesAndPullRequestsTest extends TestCase
 {
     /** @var RunQuery&MockObject */
-    private $runQuery;
+    private MockObject | RunQuery $runQuery;
 
     private GetMilestoneFirst100IssuesAndPullRequests $query;
 

--- a/test/unit/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequestsTest.php
+++ b/test/unit/Github/Api/GraphQL/Query/GetMilestoneFirst100IssuesAndPullRequestsTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 final class GetMilestoneFirst100IssuesAndPullRequestsTest extends TestCase
 {
     /** @var RunQuery&MockObject */
-    private MockObject | RunQuery $runQuery;
+    private RunQuery $runQuery;
 
     private GetMilestoneFirst100IssuesAndPullRequests $query;
 

--- a/test/unit/Github/Api/GraphQL/RunGraphQLQueryTest.php
+++ b/test/unit/Github/Api/GraphQL/RunGraphQLQueryTest.php
@@ -9,20 +9,15 @@ use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psl\SecureRandom;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
-use Webmozart\Assert\Assert;
-
-use function uniqid;
 
 final class RunGraphQLQueryTest extends TestCase
 {
     /** @var ClientInterface&MockObject */
     private ClientInterface $httpClient;
-
-    /** @var RequestFactoryInterface&MockObject */
-    private RequestFactoryInterface $messageFactory;
 
     /** @psalm-var non-empty-string */
     private string $apiToken;
@@ -33,22 +28,17 @@ final class RunGraphQLQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->httpClient     = $this->createMock(ClientInterface::class);
-        $this->messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $apiToken             = uniqid('apiToken', true);
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $messageFactory   = $this->createMock(RequestFactoryInterface::class);
 
-        Assert::notEmpty($apiToken);
-
-        $this->apiToken = $apiToken;
+        $this->apiToken = 'apiToken' . SecureRandom\string(8);
         $this->runQuery = new RunGraphQLQuery(
-            $this->messageFactory,
+            $messageFactory,
             $this->httpClient,
             $this->apiToken
         );
 
-        $this
-            ->messageFactory
-            ->expects(self::any())
+        $messageFactory
             ->method('createRequest')
             ->with('POST', 'https://api.github.com/graphql')
             ->willReturn(new Request('https://the-domain.com/the-path'));

--- a/test/unit/Github/Api/V3/CreateMilestoneTest.php
+++ b/test/unit/Github/Api/V3/CreateMilestoneTest.php
@@ -23,7 +23,7 @@ class CreateMilestoneTest extends TestCase
     /** @var ClientInterface&MockObject */
     private ClientInterface $httpClient;
     /** @var RequestFactoryInterface&MockObject */
-    private MockObject | RequestFactoryInterface $messageFactory;
+    private RequestFactoryInterface $messageFactory;
     /** @psalm-var non-empty-string */
     private string $apiToken;
     private CreateMilestoneThroughApiCall $createMilestone;

--- a/test/unit/Github/Api/V3/CreatePullRequestTest.php
+++ b/test/unit/Github/Api/V3/CreatePullRequestTest.php
@@ -11,19 +11,17 @@ use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psl\SecureRandom;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
-use Webmozart\Assert\Assert;
-
-use function uniqid;
 
 final class CreatePullRequestTest extends TestCase
 {
     /** @var ClientInterface&MockObject */
     private ClientInterface $httpClient;
 
-    /** @var RequestFactoryInterface&MockObject */
+    /** @var MockObject&RequestFactoryInterface */
     private RequestFactoryInterface $messageFactory;
 
     /** @psalm-var non-empty-string */
@@ -37,11 +35,8 @@ final class CreatePullRequestTest extends TestCase
 
         $this->httpClient     = $this->createMock(ClientInterface::class);
         $this->messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $apiToken             = uniqid('apiToken', true);
 
-        Assert::notEmpty($apiToken);
-
-        $this->apiToken          = $apiToken;
+        $this->apiToken          = 'apiToken' . SecureRandom\string(8);
         $this->createPullRequest = new CreatePullRequestThroughApiCall(
             $this->messageFactory,
             $this->httpClient,

--- a/test/unit/Github/Api/V3/CreateReleaseTest.php
+++ b/test/unit/Github/Api/V3/CreateReleaseTest.php
@@ -21,7 +21,7 @@ final class CreateReleaseTest extends TestCase
     /** @var ClientInterface&MockObject */
     private ClientInterface $httpClient;
     /** @var RequestFactoryInterface&MockObject */
-    private MockObject | RequestFactoryInterface $messageFactory;
+    private RequestFactoryInterface $messageFactory;
     /** @psalm-var non-empty-string */
     private string $apiToken;
     private CreateReleaseThroughApiCall $createRelease;

--- a/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
+++ b/test/unit/Github/Api/V3/SetDefaultBranchThroughApiCallTest.php
@@ -23,7 +23,7 @@ final class SetDefaultBranchThroughApiCallTest extends TestCase
     /** @var ClientInterface&MockObject */
     private ClientInterface $httpClient;
     /** @var RequestFactoryInterface&MockObject */
-    private MockObject | RequestFactoryInterface $messageFactory;
+    private RequestFactoryInterface $messageFactory;
     /** @psalm-var non-empty-string */
     private string $apiToken;
     private SetDefaultBranchThroughApiCall $createRelease;

--- a/test/unit/Github/Event/Factory/LoadCurrentGithubEventFromGithubActionPathTest.php
+++ b/test/unit/Github/Event/Factory/LoadCurrentGithubEventFromGithubActionPathTest.php
@@ -8,10 +8,8 @@ use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
 use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEventFromGithubActionPath;
 use Laminas\AutomaticReleases\Github\Event\MilestoneClosedEvent;
 use PHPUnit\Framework\TestCase;
-
-use function file_put_contents;
-use function sys_get_temp_dir;
-use function tempnam;
+use Psl\Env;
+use Psl\Filesystem;
 
 /** @covers \Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEventFromGithubActionPath */
 final class LoadCurrentGithubEventFromGithubActionPathTest extends TestCase
@@ -32,9 +30,9 @@ final class LoadCurrentGithubEventFromGithubActionPathTest extends TestCase
     "action": "closed"
 }
 JSON;
-        $event     = tempnam(sys_get_temp_dir(), 'github_event');
+        $event     = Filesystem\create_temporary_file(Env\temp_dir(), 'github_event');
 
-        file_put_contents($event, $eventData);
+        Filesystem\write_file($event, $eventData);
 
         $variables->method('githubEventPath')
             ->willReturn($event);

--- a/test/unit/Github/MergeMultipleReleaseNotesTest.php
+++ b/test/unit/Github/MergeMultipleReleaseNotesTest.php
@@ -13,9 +13,8 @@ use Laminas\AutomaticReleases\Github\MergeMultipleReleaseNotes;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-
-use function assert;
-use function range;
+use Psl\Type;
+use Psl\Vec;
 
 final class MergeMultipleReleaseNotesTest extends TestCase
 {
@@ -52,24 +51,26 @@ final class MergeMultipleReleaseNotesTest extends TestCase
         $this->version        = SemVerVersion::fromMilestoneName('1.0.1');
     }
 
+    /**
+     * @psalm-suppress UnusedVariable
+     */
     public function testIndicatesCannotCreateReleaseTextIfNoGeneratorCan(): void
     {
         /** @psalm-var non-empty-list<CreateReleaseText> $generators */
         $generators = [];
-        foreach (range(0, 4) as $index) {
-            $generator = $this->createMock(CreateReleaseText::class);
-            assert($generator instanceof CreateReleaseText);
-            assert($generator instanceof MockObject);
+        foreach (Vec\range(0, 4) as $index) {
+            $generator = Type\intersection(Type\object(CreateReleaseText::class), Type\object(MockObject::class))
+                ->assert($this->createMock(CreateReleaseText::class));
 
             $generator
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('canCreateReleaseText')
                 ->with(
-                    $this->equalTo($this->milestone),
-                    $this->equalTo($this->repositoryName),
-                    $this->equalTo($this->version),
-                    $this->equalTo($this->sourceBranch),
-                    $this->equalTo($this->repositoryPath)
+                    self::equalTo($this->milestone),
+                    self::equalTo($this->repositoryName),
+                    self::equalTo($this->version),
+                    self::equalTo($this->sourceBranch),
+                    self::equalTo($this->repositoryPath)
                 )
                 ->willReturn(false);
             $generators[] = $generator;
@@ -92,10 +93,10 @@ final class MergeMultipleReleaseNotesTest extends TestCase
     {
         /** @psalm-var non-empty-list<CreateReleaseText> $generators */
         $generators = [];
-        foreach (range(0, 4) as $index) {
-            $generator = $this->createMock(CreateReleaseText::class);
-            assert($generator instanceof CreateReleaseText);
-            assert($generator instanceof MockObject);
+        /** @var 0|1|2|3|4 $index */
+        foreach (Vec\range(0, 4) as $index) {
+            $generator = Type\intersection(Type\object(CreateReleaseText::class), Type\object(MockObject::class))
+                ->assert($this->createMock(CreateReleaseText::class));
 
             if ($index < 2) {
                 $generator
@@ -152,10 +153,11 @@ final class MergeMultipleReleaseNotesTest extends TestCase
     {
         /** @psalm-var non-empty-list<CreateReleaseText> $generators */
         $generators = [];
-        foreach (range(0, 4) as $index) {
-            $generator = $this->createMock(CreateReleaseText::class);
-            assert($generator instanceof CreateReleaseText);
-            assert($generator instanceof MockObject);
+
+        /** @var 0|1|2|3|4 $index */
+        foreach (Vec\range(0, 4) as $index) {
+            $generator = Type\intersection(Type\object(CreateReleaseText::class), Type\object(MockObject::class))
+                ->assert($this->createMock(CreateReleaseText::class));
 
             switch ($index) {
                 case 0:

--- a/test/unit/Github/Value/RepositoryNameTest.php
+++ b/test/unit/Github/Value/RepositoryNameTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Github\Value;
 
-use InvalidArgumentException;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use PHPUnit\Framework\TestCase;
+use Psl\Exception\InvariantViolationException;
 
 final class RepositoryNameTest extends TestCase
 {
@@ -23,10 +23,12 @@ final class RepositoryNameTest extends TestCase
                 ->__toString()
         );
 
+        /** @psalm-suppress UnusedMethodCall */
         $repositoryName->assertMatchesOwner('foo');
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvariantViolationException::class);
 
+        /** @psalm-suppress UnusedMethodCall */
         $repositoryName->assertMatchesOwner('potato');
     }
 }

--- a/test/unit/Gpg/ImportGpgKeyFromStringViaTemporaryFileTest.php
+++ b/test/unit/Gpg/ImportGpgKeyFromStringViaTemporaryFileTest.php
@@ -7,8 +7,7 @@ namespace Laminas\AutomaticReleases\Test\Unit\Gpg;
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use PHPUnit\Framework\TestCase;
-
-use function file_get_contents;
+use Psl\Filesystem;
 
 /** @covers \Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile */
 final class ImportGpgKeyFromStringViaTemporaryFileTest extends TestCase
@@ -18,7 +17,7 @@ final class ImportGpgKeyFromStringViaTemporaryFileTest extends TestCase
         self::assertEquals(
             SecretKeyId::fromBase16String('8CA5C026AE941316'),
             (new ImportGpgKeyFromStringViaTemporaryFile())
-                ->__invoke(file_get_contents(__DIR__ . '/../../asset/dummy-gpg-key.asc'))
+                ->__invoke(Filesystem\read_file(__DIR__ . '/../../asset/dummy-gpg-key.asc'))
         );
     }
 }

--- a/test/unit/Gpg/SecretKeyIdTest.php
+++ b/test/unit/Gpg/SecretKeyIdTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Test\Unit\Gpg;
 
-use InvalidArgumentException;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 use PHPUnit\Framework\TestCase;
+use Psl\Exception\InvariantViolationException;
 
 final class SecretKeyIdTest extends TestCase
 {
@@ -15,7 +15,7 @@ final class SecretKeyIdTest extends TestCase
      */
     public function testRejectsInvalidKeyIds(string $invalid): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvariantViolationException::class);
 
         SecretKeyId::fromBase16String($invalid);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Similar to https://github.com/Roave/BackwardCompatibilityCheck/pull/306, this PR replaces `thecodingmachine/safe`, `webmozart/assert`, and `symfony/process` by `azjezz/psl`.

This reduces the amount of dependencies, and relies on a better type assertion component provided by PSL.

Psl also ships with functions that replace PHP builtin to provide a better error handling, and consistency.

`symfony/process` is not made absolute by `Psl\Shell\execute`, as `execute` function is created as a replacement for `exec` builtin function, however, it provides enough functionality ( working directory, argument escaping, environment variables .. etc ) to replace the usage of `symfony/process` within this library ( if more features are needed later on, it makes sense to bring `symfony/process` back ).
