### PR TITLE
Private repository release support

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\WebApplication;
 
+use ChangelogGenerator\GitHubOAuthToken;
 use DateTimeZone;
 use ErrorException;
 use Http\Discovery\HttpClientDiscovery;
@@ -86,7 +87,8 @@ use const STDERR;
     );
     $createCommitText     = new CreateReleaseTextThroughChangelog(JwageGenerateChangelog::create(
         $makeRequests,
-        $httpClient
+        $httpClient,
+        new GitHubOAuthToken($githubToken)
     ));
     $createReleaseText    = new MergeMultipleReleaseNotes([
         new CreateReleaseTextViaKeepAChangelog($changelogExists, new SystemClock(new DateTimeZone('UTC'))),

--- a/src/Github/JwageGenerateChangelog.php
+++ b/src/Github/JwageGenerateChangelog.php
@@ -7,7 +7,6 @@ namespace Laminas\AutomaticReleases\Github;
 use ChangelogGenerator\ChangelogConfig;
 use ChangelogGenerator\ChangelogGenerator;
 use ChangelogGenerator\GitHubCredentials;
-use ChangelogGenerator\GitHubOAuthToken;
 use ChangelogGenerator\IssueClient;
 use ChangelogGenerator\IssueFactory;
 use ChangelogGenerator\IssueFetcher;

--- a/test/unit/Github/JwageGenerateChangelogTest.php
+++ b/test/unit/Github/JwageGenerateChangelogTest.php
@@ -6,11 +6,16 @@ namespace Laminas\AutomaticReleases\Test\Unit\Github;
 
 use ChangelogGenerator\ChangelogConfig;
 use ChangelogGenerator\ChangelogGenerator;
+use ChangelogGenerator\GitHubCredentials;
 use ChangelogGenerator\GitHubOAuthToken;
+use Http\Client\HttpClient;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestFactoryInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class JwageGenerateChangelogTest extends TestCase
@@ -38,5 +43,20 @@ final class JwageGenerateChangelogTest extends TestCase
 
         (new JwageGenerateChangelog($changelogGenerator, $githubCredentials))
             ->__invoke($repositoryName, $semVerVersion);
+    }
+
+    public function testCreateGenerateChangelog(): void
+    {
+        $makeRequests = $this->createMock(RequestFactoryInterface::class);
+        $httpClient   = $this->createMock(HttpClient::class);
+        $githubToken  = $this->createMock(GitHubCredentials::class);
+
+        $changeLogGenerator = JwageGenerateChangelog::create(
+            $makeRequests,
+            $httpClient,
+            $githubToken
+        );
+
+        $this->assertInstanceOf(JwageGenerateChangelog::class, $changeLogGenerator);
     }
 }

--- a/test/unit/Github/JwageGenerateChangelogTest.php
+++ b/test/unit/Github/JwageGenerateChangelogTest.php
@@ -6,6 +6,7 @@ namespace Laminas\AutomaticReleases\Test\Unit\Github;
 
 use ChangelogGenerator\ChangelogConfig;
 use ChangelogGenerator\ChangelogGenerator;
+use ChangelogGenerator\GitHubOAuthToken;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;
@@ -16,10 +17,13 @@ final class JwageGenerateChangelogTest extends TestCase
 {
     public function testGenerateChangelog(): void
     {
+        $githubCredentials = new GitHubOAuthToken('token');
+
         $config = (new ChangelogConfig())
             ->setUser('laminas')
             ->setRepository('repository-name')
-            ->setMilestone('1.0.0');
+            ->setMilestone('1.0.0')
+            ->setGitHubCredentials($githubCredentials);
 
         $output = new BufferedOutput();
 
@@ -32,7 +36,7 @@ final class JwageGenerateChangelogTest extends TestCase
         $repositoryName = RepositoryName::fromFullName('laminas/repository-name');
         $semVerVersion  = SemVerVersion::fromMilestoneName('1.0.0');
 
-        (new JwageGenerateChangelog($changelogGenerator))
+        (new JwageGenerateChangelog($changelogGenerator, $githubCredentials))
             ->__invoke($repositoryName, $semVerVersion);
     }
 }

--- a/test/unit/Github/JwageGenerateChangelogTest.php
+++ b/test/unit/Github/JwageGenerateChangelogTest.php
@@ -9,8 +9,6 @@ use ChangelogGenerator\ChangelogGenerator;
 use ChangelogGenerator\GitHubCredentials;
 use ChangelogGenerator\GitHubOAuthToken;
 use Http\Client\HttpClient;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\Psr17FactoryDiscovery;
 use Laminas\AutomaticReleases\Git\Value\SemVerVersion;
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
 use Laminas\AutomaticReleases\Github\Value\RepositoryName;


### PR DESCRIPTION
Fixing [#139](https://github.com/laminas/automatic-releases/issues/139) to allow usage on private repositories.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #139