### PR TITLE
Use `git config credential.helper 'store --file=/tmp/file' for `git push`

### DIFF
--- a/src/Application/Command/BumpChangelogForReleaseBranch.php
+++ b/src/Application/Command/BumpChangelogForReleaseBranch.php
@@ -44,12 +44,15 @@ final class BumpChangelogForReleaseBranch extends Command
     {
         $milestoneClosedEvent = ($this->loadEvent)();
         $repositoryName       = $milestoneClosedEvent->repository();
-        $repositoryCloneUri   = $repositoryName->uriWithTokenAuthentication($this->environment->githubToken());
         $repositoryPath       = $this->environment->githubWorkspacePath();
 
         Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
-        ($this->fetch)($repositoryCloneUri, $repositoryPath);
+        ($this->fetch)(
+            $repositoryName->uri(),
+            $repositoryName->uriWithTokenAuthentication($this->environment->githubToken()),
+            $repositoryPath
+        );
 
         $mergeCandidates = ($this->getMergeTargets)($repositoryPath);
         $releaseVersion  = $milestoneClosedEvent->version();

--- a/src/Application/Command/CreateMergeUpPullRequest.php
+++ b/src/Application/Command/CreateMergeUpPullRequest.php
@@ -58,12 +58,13 @@ final class CreateMergeUpPullRequest extends Command
     {
         $event          = $this->loadGithubEvent->__invoke();
         $repositoryPath = $this->variables->githubWorkspacePath();
+        $repositoryName = $event->repository();
 
         Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
         $this->fetch->__invoke(
-            $event->repository()
-                ->uriWithTokenAuthentication($this->variables->githubToken()),
+            $repositoryName->uri(),
+            $repositoryName->uriWithTokenAuthentication($this->variables->githubToken()),
             $repositoryPath
         );
 

--- a/src/Application/Command/ReleaseCommand.php
+++ b/src/Application/Command/ReleaseCommand.php
@@ -64,12 +64,15 @@ final class ReleaseCommand extends Command
     {
         $milestoneClosedEvent = ($this->loadEvent)();
         $repositoryName       = $milestoneClosedEvent->repository();
-        $repositoryCloneUri   = $repositoryName->uriWithTokenAuthentication($this->environment->githubToken());
         $repositoryPath       = $this->environment->githubWorkspacePath();
 
         Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
-        ($this->fetch)($repositoryCloneUri, $repositoryPath);
+        ($this->fetch)(
+            $repositoryName->uri(),
+            $repositoryName->uriWithTokenAuthentication($this->environment->githubToken()),
+            $repositoryPath
+        );
 
         $mergeCandidates = ($this->getMergeTargets)($repositoryPath);
         $releaseVersion  = $milestoneClosedEvent->version();

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -51,12 +51,13 @@ final class SwitchDefaultBranchToNextMinor extends Command
     {
         $event          = $this->loadGithubEvent->__invoke();
         $repositoryPath = $this->variables->githubWorkspacePath();
+        $repositoryName = $event->repository();
 
         Psl\invariant(Filesystem\is_directory($repositoryPath . '/.git'), 'Workspace is not a GIT repository.');
 
         $this->fetch->__invoke(
-            $event->repository()
-                ->uriWithTokenAuthentication($this->variables->githubToken()),
+            $repositoryName->uri(),
+            $repositoryName->uriWithTokenAuthentication($this->variables->githubToken()),
             $repositoryPath
         );
 

--- a/src/Git/Fetch.php
+++ b/src/Git/Fetch.php
@@ -11,6 +11,7 @@ interface Fetch
     /** @psalm-param non-empty-string $repositoryRootDirectory */
     public function __invoke(
         UriInterface $repositoryUri,
+        UriInterface $uriWithCredentials,
         string $repositoryRootDirectory
     ): void;
 }

--- a/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
+++ b/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Environment\EnvironmentVariables;
+use Psl\File;
+use Psl\Filesystem;
 use Psl\Shell;
 use Psr\Http\Message\UriInterface;
 
@@ -19,6 +21,7 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
 
     public function __invoke(
         UriInterface $repositoryUri,
+        UriInterface $uriWithCredentials,
         string $repositoryRootDirectory
     ): void {
         try {
@@ -26,6 +29,10 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
         } catch (Shell\Exception\FailedExecutionException) {
         }
 
+        $credentialStore = Filesystem\create_temporary_file();
+
+        Shell\execute('git', ['config', 'credential.helper', 'store --file=' . $credentialStore], $repositoryRootDirectory);
+        File\write($credentialStore, $uriWithCredentials->__toString());
         Shell\execute('git', ['remote', 'add', 'origin', $repositoryUri->__toString()], $repositoryRootDirectory);
         Shell\execute('git', ['fetch', 'origin'], $repositoryRootDirectory);
         Shell\execute('git', ['config', 'user.email', $this->variables->gitAuthorEmail()], $repositoryRootDirectory);

--- a/src/Github/Value/RepositoryName.php
+++ b/src/Github/Value/RepositoryName.php
@@ -52,6 +52,11 @@ final class RepositoryName
         Psl\invariant(Str\lowercase($owner) === Str\lowercase($this->owner), 'Failed asserting that "%s" matches repository name owner.', $owner);
     }
 
+    public function uri(): UriInterface
+    {
+        return new Uri('https://@github.com/' . $this->owner . '/' . $this->name . '.git');
+    }
+
     /** @psalm-param non-empty-string $token */
     public function uriWithTokenAuthentication(string $token): UriInterface
     {

--- a/test/unit/Application/BumpChangelogForReleaseBranchTest.php
+++ b/test/unit/Application/BumpChangelogForReleaseBranchTest.php
@@ -94,6 +94,7 @@ class BumpChangelogForReleaseBranchTest extends TestCase
         $this->fetch->expects(self::once())
             ->method('__invoke')
             ->with(
+                'https://github.com/foo/bar.git',
                 'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
                 $workspace
             );

--- a/test/unit/Application/CreateMergeUpPullRequestTest.php
+++ b/test/unit/Application/CreateMergeUpPullRequestTest.php
@@ -142,7 +142,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)
@@ -208,7 +212,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)

--- a/test/unit/Application/ReleaseCommandTest.php
+++ b/test/unit/Application/ReleaseCommandTest.php
@@ -152,7 +152,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -113,7 +113,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)
@@ -156,7 +160,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)
@@ -205,7 +213,11 @@ JSON
 
         $this->fetch->expects(self::once())
             ->method('__invoke')
-            ->with('https://github-auth-token:x-oauth-basic@github.com/foo/bar.git', $workspace);
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace
+            );
 
         $this->getMergeTargets->method('__invoke')
             ->with($workspace)

--- a/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
+++ b/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
@@ -13,6 +13,7 @@ use Psl\Filesystem;
 use Psl\Shell;
 use Psl\Str;
 use Psr\Http\Message\UriInterface;
+use Throwable;
 
 /** @covers \Laminas\AutomaticReleases\Git\FetchAndSetCurrentUserByReplacingCurrentOriginRemote */
 final class FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest extends TestCase
@@ -104,5 +105,28 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest extends Tes
 
         self::assertStringContainsString('origin/initial-branch', $fetchedBranches);
         self::assertStringContainsString('origin/new-branch', $fetchedBranches);
+    }
+
+    public function testFailingToSetARemoteWillNotLeadToSecretExfiltration(): void
+    {
+        $sourceUri            = $this->createMock(UriInterface::class);
+        $sourceUriWithSecrets = $this->createMock(UriInterface::class);
+
+        $sourceUri->method('__toString')
+            ->willReturn('https://github.com/laminas/this-repository-does-not-exist.git');
+        $sourceUriWithSecrets->method('__toString')
+            ->willReturn('https://SUPERSECRET:x-oauth-basic@github.com/laminas/this-repository-does-not-exist.git');
+
+        $notAGitDirectory = Filesystem\create_temporary_file();
+
+        Filesystem\delete_file($notAGitDirectory);
+        Filesystem\create_directory($notAGitDirectory);
+
+        try {
+            (new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($this->variables))
+                ->__invoke($sourceUri, $sourceUriWithSecrets, $notAGitDirectory);
+        } catch (Throwable $failure) {
+            self::assertDoesNotMatchRegularExpression('/SUPERSECRET/m', $failure->getMessage());
+        }
     }
 }

--- a/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
+++ b/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
@@ -62,7 +62,7 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest extends Tes
             ->willReturn($this->source);
 
         (new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($this->variables))
-            ->__invoke($sourceUri, $this->destination);
+            ->__invoke($sourceUri, $sourceUri, $this->destination);
 
         self::assertSame(
             'Mr. Magoo Set',
@@ -89,7 +89,7 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest extends Tes
         Shell\execute('git', ['remote', 'rm', 'origin'], $this->destination);
 
         (new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($this->variables))
-            ->__invoke($sourceUri, $this->destination);
+            ->__invoke($sourceUri, $sourceUri, $this->destination);
 
         self::assertSame(
             'Mr. Magoo Set',

--- a/test/unit/Github/Value/RepositoryNameTest.php
+++ b/test/unit/Github/Value/RepositoryNameTest.php
@@ -17,6 +17,12 @@ final class RepositoryNameTest extends TestCase
         self::assertSame('foo', $repositoryName->owner());
         self::assertSame('bar', $repositoryName->name());
         self::assertSame(
+            'https://github.com/foo/bar.git',
+            $repositoryName
+                ->uri()
+                ->__toString()
+        );
+        self::assertSame(
             'https://token:x-oauth-basic@github.com/foo/bar.git',
             $repositoryName
                 ->uriWithTokenAuthentication('token')


### PR DESCRIPTION
This should fix some underlying design issues described in #198
    
The full URI of the repository, which includes a token in plaintext, is now no
longer the actual `git remote` URI, and is instead stored in a temporary
file which `git` uses to authenticate with the remote.
    
This prevents the remote URI from leaking in `STDOUT`/`STDERR`, which are
visible in case of crashes.

This is a **partial** fix of #198 - the issue with `git` being broken upfront is still there. 