### PR TITLE
Fix #198 - make GIT's `safe.directory` `'*'` by default on repository fetch

### DIFF
--- a/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
+++ b/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
@@ -31,6 +31,7 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
 
         $credentialStore = Filesystem\create_temporary_file();
 
+        Shell\execute('git', ['config', '--global', '--add', 'safe.directory', '*'], $repositoryRootDirectory);
         Shell\execute('git', ['config', 'credential.helper', 'store --file=' . $credentialStore], $repositoryRootDirectory);
         File\write($credentialStore, $uriWithCredentials->__toString());
         Shell\execute('git', ['remote', 'add', 'origin', $repositoryUri->__toString()], $repositoryRootDirectory);

--- a/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
+++ b/test/unit/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest.php
@@ -129,4 +129,20 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemoteTest extends Tes
             self::assertDoesNotMatchRegularExpression('/SUPERSECRET/m', $failure->getMessage());
         }
     }
+
+    public function testGlobalGitConfigurationIsAdaptedToAllowCheckedOutRepositoryUsage(): void
+    {
+        $sourceUri = $this->createMock(UriInterface::class);
+
+        $sourceUri->method('__toString')
+            ->willReturn($this->source);
+
+        (new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($this->variables))
+            ->__invoke($sourceUri, $sourceUri, $this->destination);
+
+        self::assertSame(
+            '*',
+            Str\trim(Shell\execute('git', ['config', '--get', 'safe.directory'], $this->destination))
+        );
+    }
 }


### PR DESCRIPTION
This is an ugly side-effect, and it will modify the environment of users that rely on this package
outside the context of the delivered docker container, but it is a good workaround for the security
and compatibility mess that GIT 2.35.3 introduced.

In fact, this application was never meant to run in multi-user mode, and the container it runs will
not be affected by side effects (mostly git hooks) in freshly checked out code.

Ref: https://stackoverflow.com/a/71904131/347063
Ref: https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
Ref: https://marc.info/?l=git&m=164989570902912&w=2
Ref: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
Ref: https://github.com/git-for-windows/git/issues/3809#issuecomment-1102681740
