### PR TITLE
Make sure git `safe.directory` is disabled before removing `origin` remote

### DIFF
--- a/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
+++ b/src/Git/FetchAndSetCurrentUserByReplacingCurrentOriginRemote.php
@@ -24,6 +24,8 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
         UriInterface $uriWithCredentials,
         string $repositoryRootDirectory
     ): void {
+        Shell\execute('git', ['config', '--global', '--add', 'safe.directory', '*'], $repositoryRootDirectory);
+
         try {
             Shell\execute('git', ['remote', 'rm', 'origin'], $repositoryRootDirectory);
         } catch (Shell\Exception\FailedExecutionException) {
@@ -31,7 +33,6 @@ final class FetchAndSetCurrentUserByReplacingCurrentOriginRemote implements Fetc
 
         $credentialStore = Filesystem\create_temporary_file();
 
-        Shell\execute('git', ['config', '--global', '--add', 'safe.directory', '*'], $repositoryRootDirectory);
         Shell\execute('git', ['config', 'credential.helper', 'store --file=' . $credentialStore], $repositoryRootDirectory);
         File\write($credentialStore, $uriWithCredentials->__toString());
         Shell\execute('git', ['remote', 'add', 'origin', $repositoryUri->__toString()], $repositoryRootDirectory);


### PR DESCRIPTION
Without this change, the remote named `origin` cannot be removed, because `git` refuses to operate on the current directory.  