### PR TITLE
Better default branch rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,18 @@
         "psr-4": {
             "Laminas\\AutomaticReleases\\Test\\Unit\\": "test/unit"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@static-analysis",
+            "@test"
+        ],
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
+        "update-baseline": "psalm --update-baseline",
+        "test": "phpunit --colors=always",
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -5658,16 +5658,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
@@ -5720,7 +5720,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
             "funding": [
                 {
@@ -5728,7 +5728,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:49:45+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -5918,16 +5918,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
@@ -5983,7 +5983,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
             },
             "funding": [
                 {
@@ -5991,7 +5991,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T14:18:36+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -6346,16 +6346,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb44e1cc6e557418387ad815780360057e40753e"
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb44e1cc6e557418387ad815780360057e40753e",
-                "reference": "fb44e1cc6e557418387ad815780360057e40753e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
                 "shasum": ""
             },
             "require": {
@@ -6367,7 +6367,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -6390,7 +6390,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
             },
             "funding": [
                 {
@@ -6398,7 +6398,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-29T06:55:37+00:00"
+            "time": "2022-09-12T14:47:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -6824,16 +6824,16 @@
         },
         {
             "name": "thecodingmachine/safe",
-            "version": "v2.2.3",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "e454a3142d2197694d1fda291a4462ccd3f66e12"
+                "reference": "dc8df8f5047e7d3021a3f41f492dc99f8b3dc475"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/e454a3142d2197694d1fda291a4462ccd3f66e12",
-                "reference": "e454a3142d2197694d1fda291a4462ccd3f66e12",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/dc8df8f5047e7d3021a3f41f492dc99f8b3dc475",
+                "reference": "dc8df8f5047e7d3021a3f41f492dc99f8b3dc475",
                 "shasum": ""
             },
             "require": {
@@ -6956,9 +6956,9 @@
             "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
             "support": {
                 "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v2.2.3"
+                "source": "https://github.com/thecodingmachine/safe/tree/v2.3.0"
             },
-            "time": "2022-08-04T14:05:49+00:00"
+            "time": "2022-09-13T15:49:48+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/feature/default-branch-switching.feature
+++ b/feature/default-branch-switching.feature
@@ -40,7 +40,49 @@ Feature: Default branch switching
       | 1.3.x  |
     And the default branch should be "1.3.x"
 
-  Scenario: A pre-existing branch of a greater major release is set as default branch on release
+  Scenario: A new minor branch on a pre-existing major branch is created and set as default branch on release
+    Given following existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 2.0.x  |
+    And following open milestones:
+      | name  |
+      | 2.0.0 |
+    And the default branch is "1.0.x"
+    When I close milestone "2.0.0"
+    Then these should be the existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 2.0.x  |
+      | 2.1.x  |
+    And the default branch should be "2.1.x"
+
+  Scenario: A pre-existing branch of a new major release is not set as default branch on release
+    Given following existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 2.0.x  |
+    And following open milestones:
+      | name  |
+      | 1.2.0 |
+    And the default branch is "1.0.x"
+    When I close milestone "1.2.0"
+    Then these should be the existing branches:
+      | branch |
+      | 1.0.x  |
+      | 1.1.x  |
+      | 1.2.x  |
+      | 1.3.x  |
+      | 2.0.x  |
+    And the default branch should be "1.3.x"
+
+  Scenario: A pre-existing minor branch of a greater major release is set as default branch on release
     Given following existing branches:
       | branch |
       | 1.0.x  |

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -82,7 +82,9 @@ final class MergeTargetCandidateBranches
         $futureReleaseBranch = Vec\filter(
             Vec\reverse($this->sortedBranches),
             static function (BranchName $branch) use ($nextMinor): bool {
-                return $nextMinor->lessThanEqual($branch->targetMinorReleaseVersion());
+                $targetVersion = $branch->targetMinorReleaseVersion();
+
+                return ! $targetVersion->isNewMajorRelease() && $nextMinor->lessThanEqual($targetVersion);
             },
         );
 

--- a/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
+++ b/test/unit/Git/Value/MergeTargetCandidateBranchesTest.php
@@ -159,6 +159,53 @@ final class MergeTargetCandidateBranchesTest extends TestCase
         );
     }
 
+    public function testWillIgnoreNewMajorBranchesWhenComputingFutureReleaseBranchName(): void
+    {
+        $branches = MergeTargetCandidateBranches::fromAllBranches(
+            BranchName::fromName('2.0.x'),
+            BranchName::fromName('1.1.x'),
+            BranchName::fromName('1.4.x'),
+            BranchName::fromName('1.2.x'),
+        );
+
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.0.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.1.1')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.2.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.4.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.3.1')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.5.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.4.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('1.6.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('1.5.0')),
+        );
+        self::assertEquals(
+            BranchName::fromName('2.1.x'),
+            $branches->newestFutureReleaseBranchAfter(SemVerVersion::fromMilestoneName('2.0.0')),
+        );
+    }
+
     public function testWillIgnoreMasterBranchWhenComputingFutureReleaseBranchName(): void
     {
         $branches = MergeTargetCandidateBranches::fromAllBranches(


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
This PR:
- Fixes https://github.com/laminas/automatic-releases/issues/209)
- Adds further feature documentation to describe this PRs intention to fix the above
- Adds a failing test to ensure what is documented
- Updates dependencies in `composer.lock`

I'm not certain if this is the best approach, as it just ignores the new major branches when computing the new default.

Edit: I've reviewed the[ logs generated by the infection check](https://github.com/laminas/automatic-releases/actions/runs/3064533831/jobs/4947714591#step:3:574) showing 14 escaped mutants (including from this change) and 1 error, however when I run the tool locally I get 6 and this change is not mentioned:

<details><summary>Local logs</summary>

```
$ roave-infection-static-analysis-plugin --psalm-config psalm.xml.dist 

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

#StandWithUkraine

Infection - PHP Mutation Testing Framework version 0.26.14

[notice] You are running Infection with PCOV enabled.

Running initial test suite...

PHPUnit version: 9.5.24

  228 [============================] 14 secs

Generate mutants...

Processing source code files: 59/59
.: killed, M: escaped, U: uncovered, E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored

UUUUUU............................................   ( 50 / 679)
..................................................   (100 / 679)
..................................................   (150 / 679)
..................................................   (200 / 679)
..................................................   (250 / 679)
..................................................   (300 / 679)
..................................................   (350 / 679)
..................................................   (400 / 679)
..................................................   (450 / 679)
..................................................   (500 / 679)
..................................................   (550 / 679)
..................................................   (600 / 679)
..................................................   (650 / 679)
.............................                        (679 / 679)

679 mutations were generated:
     673 mutants were killed
       0 mutants were configured to be ignored
       6 mutants were not covered by tests
       0 covered mutants were not detected
       0 errors were encountered
       0 syntax errors were encountered
       0 time outs were encountered
       0 mutants required more time than configured

Metrics:
         Mutation Score Indicator (MSI): 99%
         Mutation Code Coverage: 99%
         Covered Code MSI: 100%

Note: to see escaped mutants run Infection with "--show-mutations" or configure file loggers.

Please note that some mutants will inevitably be harmless (i.e. false positives).
Escaped mutants:
================

Timed Out mutants:
==================

Skipped mutants:
================

Not Covered mutants:
====================

1) /laminas/automatic-releases/src/Changelog/ChangelogReleaseNotes.php:61    [M] Concat

--- Original
+++ New
@@ @@
     public function merge(self $next) : self
     {
         if ($this->changelogEntry && $next->changelogEntry) {
-            throw new RuntimeException('Aborting: Both current release notes and next contain a ChangelogEntry;' . ' only one CreateReleaseText implementation should resolve one.');
+            throw new RuntimeException(' only one CreateReleaseText implementation should resolve one.' . 'Aborting: Both current release notes and next contain a ChangelogEntry;');
         }
         $changelogEntry = $this->changelogEntry ?: $next->changelogEntry;
         if ($changelogEntry) {


2) /laminas/automatic-releases/src/Changelog/ChangelogReleaseNotes.php:61    [M] ConcatOperandRemoval

--- Original
+++ New
@@ @@
     public function merge(self $next) : self
     {
         if ($this->changelogEntry && $next->changelogEntry) {
-            throw new RuntimeException('Aborting: Both current release notes and next contain a ChangelogEntry;' . ' only one CreateReleaseText implementation should resolve one.');
+            throw new RuntimeException(' only one CreateReleaseText implementation should resolve one.');
         }
         $changelogEntry = $this->changelogEntry ?: $next->changelogEntry;
         if ($changelogEntry) {


3) /laminas/automatic-releases/src/Changelog/ChangelogReleaseNotes.php:61    [M] ConcatOperandRemoval

--- Original
+++ New
@@ @@
     public function merge(self $next) : self
     {
         if ($this->changelogEntry && $next->changelogEntry) {
-            throw new RuntimeException('Aborting: Both current release notes and next contain a ChangelogEntry;' . ' only one CreateReleaseText implementation should resolve one.');
+            throw new RuntimeException('Aborting: Both current release notes and next contain a ChangelogEntry;');
         }
         $changelogEntry = $this->changelogEntry ?: $next->changelogEntry;
         if ($changelogEntry) {


4) /laminas/automatic-releases/src/Environment/EnvironmentVariables.php:56    [M] Concat

--- Original
+++ New
@@ @@
     private function __construct(private readonly string $githubToken, private readonly SecretKeyId $signingSecretKey, private readonly string $gitAuthorName, private readonly string $gitAuthorEmail, private readonly string $githubEventPath, private readonly string $workspacePath, private readonly string $logLevel)
     {
         /** @psalm-suppress ImpureFunctionCall the {@see \Psl\Iter\contains()} API is conditionally pure */
-        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), 'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;' . ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels');
+        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels' . 'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;');
     }
     public static function fromEnvironment(ImportGpgKeyFromString $importKey) : self
     {


5) /laminas/automatic-releases/src/Environment/EnvironmentVariables.php:56    [M] ConcatOperandRemoval

--- Original
+++ New
@@ @@
     private function __construct(private readonly string $githubToken, private readonly SecretKeyId $signingSecretKey, private readonly string $gitAuthorName, private readonly string $gitAuthorEmail, private readonly string $githubEventPath, private readonly string $workspacePath, private readonly string $logLevel)
     {
         /** @psalm-suppress ImpureFunctionCall the {@see \Psl\Iter\contains()} API is conditionally pure */
-        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), 'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;' . ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels');
+        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels');
     }
     public static function fromEnvironment(ImportGpgKeyFromString $importKey) : self
     {


6) /laminas/automatic-releases/src/Environment/EnvironmentVariables.php:56    [M] ConcatOperandRemoval

--- Original
+++ New
@@ @@
     private function __construct(private readonly string $githubToken, private readonly SecretKeyId $signingSecretKey, private readonly string $gitAuthorName, private readonly string $gitAuthorEmail, private readonly string $githubEventPath, private readonly string $workspacePath, private readonly string $logLevel)
     {
         /** @psalm-suppress ImpureFunctionCall the {@see \Psl\Iter\contains()} API is conditionally pure */
-        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), 'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;' . ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels');
+        Psl\invariant(Iter\contains(self::LOG_LEVELS, $logLevel), 'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;');
     }
     public static function fromEnvironment(ImportGpgKeyFromString $importKey) : self
     {
 ! [NOTE] The MSI is 2.12% percentage points over the required MSI. Consider increasing the required MSI percentage the 
 !        next time you run Infection.                                                                                  


Time: 4m 39s. Memory: 0.14GB

```

</details>