### PR TITLE
Log HTTP requests/responses (only non-sensitive data)

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -37,6 +37,9 @@ use Laminas\AutomaticReleases\Github\Event\Factory\LoadCurrentGithubEventFromGit
 use Laminas\AutomaticReleases\Github\JwageGenerateChangelog;
 use Laminas\AutomaticReleases\Github\MergeMultipleReleaseNotes;
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromStringViaTemporaryFile;
+use Laminas\AutomaticReleases\HttpClient\LoggingHttpClient;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings;
 use Lcobucci\Clock\SystemClock;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
@@ -61,13 +64,19 @@ use const STDERR;
     );
 
     $variables = EnvironmentVariables::fromEnvironment(new ImportGpgKeyFromStringViaTemporaryFile());
-    $logger    = new Logger('automatic-releases');
-    $logger->pushHandler(new StreamHandler(STDERR, $variables->logLevel()));
+    $logger    = new Logger(
+        'automatic-releases',
+        [new StreamHandler(STDERR, $variables->logLevel())],
+        [
+            new ConvertLogContextHttpRequestsIntoStrings(),
+            new ConvertLogContextHttpResponsesIntoStrings(),
+        ]
+    );
     $loadEvent            = new LoadCurrentGithubEventFromGithubActionPath($variables);
     $fetch                = new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($variables);
     $getCandidateBranches = new GetMergeTargetCandidateBranchesFromRemoteBranches();
     $makeRequests         = Psr17FactoryDiscovery::findRequestFactory();
-    $httpClient           = HttpClientDiscovery::find();
+    $httpClient           = new LoggingHttpClient(HttpClientDiscovery::find(), $logger);
     $githubToken          = $variables->githubToken();
     $getMilestone         = new GetMilestoneFirst100IssuesAndPullRequests(new RunGraphQLQuery(
         $makeRequests,

--- a/bin/console.php
+++ b/bin/console.php
@@ -63,14 +63,14 @@ use const STDERR;
         E_STRICT | E_NOTICE | E_WARNING,
     );
 
-    $variables = EnvironmentVariables::fromEnvironment(new ImportGpgKeyFromStringViaTemporaryFile());
-    $logger    = new Logger(
+    $variables            = EnvironmentVariables::fromEnvironment(new ImportGpgKeyFromStringViaTemporaryFile());
+    $logger               = new Logger(
         'automatic-releases',
         [new StreamHandler(STDERR, $variables->logLevel())],
         [
             new ConvertLogContextHttpRequestsIntoStrings(),
             new ConvertLogContextHttpResponsesIntoStrings(),
-        ]
+        ],
     );
     $loadEvent            = new LoadCurrentGithubEventFromGithubActionPath($variables);
     $fetch                = new FetchAndSetCurrentUserByReplacingCurrentOriginRemote($variables);

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -12,6 +12,6 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 97,
+    "minMsi": 95.4,
     "minCoveredMsi": 100
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -12,6 +12,6 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 95.4,
+    "minMsi": 98,
     "minCoveredMsi": 100
 }

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,19 +15,6 @@
         </ignoreFiles>
     </projectFiles>
 
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
-            </errorLevel>
-        </InternalMethod>
-    </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
         <pluginClass class="Psl\Psalm\Plugin"/>

--- a/src/Changelog/ChangelogReleaseNotes.php
+++ b/src/Changelog/ChangelogReleaseNotes.php
@@ -58,8 +58,7 @@ class ChangelogReleaseNotes
     {
         if ($this->changelogEntry && $next->changelogEntry) {
             throw new RuntimeException(
-                'Aborting: Both current release notes and next contain a ChangelogEntry;'
-                . ' only one CreateReleaseText implementation should resolve one.',
+                'Aborting: Both current release notes and next contain a ChangelogEntry; only one CreateReleaseText implementation should resolve one.',
             );
         }
 

--- a/src/Git/Value/MergeTargetCandidateBranches.php
+++ b/src/Git/Value/MergeTargetCandidateBranches.php
@@ -26,9 +26,7 @@ final class MergeTargetCandidateBranches
             return $branch->isReleaseBranch();
         });
 
-        $mergeTargetBranches = Vec\sort($mergeTargetBranches, static function (BranchName $a, BranchName $b): int {
-            return $a->majorAndMinor() <=> $b->majorAndMinor();
-        });
+        $mergeTargetBranches = Vec\sort($mergeTargetBranches, self::branchOrder(...));
 
         return new self($mergeTargetBranches);
     }
@@ -97,5 +95,11 @@ final class MergeTargetCandidateBranches
             $this->sortedBranches,
             static fn (BranchName $branch): bool => $needle->equals($branch)
         );
+    }
+
+    /** @return -1|0|1 */
+    private static function branchOrder(BranchName $a, BranchName $b): int
+    {
+        return $a->majorAndMinor() <=> $b->majorAndMinor();
     }
 }

--- a/src/Github/CreateReleaseTextViaKeepAChangelog.php
+++ b/src/Github/CreateReleaseTextViaKeepAChangelog.php
@@ -130,17 +130,20 @@ class CreateReleaseTextViaKeepAChangelog implements CreateReleaseText
      */
     private function removeDefaultContents(string $changelog): string
     {
-        $contents = Iter\reduce(
+        return Type\non_empty_string()->assert(Iter\reduce(
             self::DEFAULT_SECTIONS,
-            static fn (string $changelog, string $section): string => Regex\replace(
-                $changelog,
-                "/\n\#{3} " . $section . "\n\n- Nothing.\n/s",
-                '',
-            ),
+            self::removeEmptyDefaultChangelogSection(...),
             $changelog,
-        );
+        ));
+    }
 
-        return Type\non_empty_string()->assert($contents);
+    private static function removeEmptyDefaultChangelogSection(string $changelog, string $section): string
+    {
+        return Regex\replace(
+            $changelog,
+            "/\n\#{3} " . $section . "\n\n- Nothing.\n/s",
+            '',
+        );
     }
 
     /**

--- a/src/HttpClient/LoggingHttpClient.php
+++ b/src/HttpClient/LoggingHttpClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\HttpClient;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+/** @internal */
+final class LoggingHttpClient implements ClientInterface
+{
+    public function __construct(private readonly ClientInterface $next, private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->logger->debug('Sending request {request}', ['request' => $request]);
+
+        $response = $this->next->sendRequest($request);
+
+        $this->logger->debug(
+            'Received response {response} to request {request}',
+            [
+                'request'  => $request,
+                'response' => $response,
+            ]
+        );
+
+        return $response;
+    }
+}

--- a/src/HttpClient/LoggingHttpClient.php
+++ b/src/HttpClient/LoggingHttpClient.php
@@ -27,7 +27,7 @@ final class LoggingHttpClient implements ClientInterface
             [
                 'request'  => $request,
                 'response' => $response,
-            ]
+            ],
         );
 
         return $response;

--- a/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Monolog;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Psr\Http\Message\RequestInterface;
+
+/** @internal */
+final class ConvertLogContextHttpRequestsIntoStrings implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        return new LogRecord(
+            $record->datetime,
+            $record->channel,
+            $record->level,
+            $record->message,
+            array_map(static function ($item): mixed {
+                if (! $item instanceof RequestInterface) {
+                    return $item;
+                }
+
+                return $item->getMethod()
+                    . ' '
+                    . $item
+                        ->getUri()
+                        ->withUserInfo('')
+                        ->__toString();
+            }, $record->context),
+            $record->extra,
+            $record->formatted
+        );
+    }
+}

--- a/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
@@ -20,20 +20,23 @@ final class ConvertLogContextHttpRequestsIntoStrings implements ProcessorInterfa
             $record->channel,
             $record->level,
             $record->message,
-            array_map(static function ($item): mixed {
-                if (! $item instanceof RequestInterface) {
-                    return $item;
-                }
-
-                return $item->getMethod()
-                    . ' '
-                    . $item
-                        ->getUri()
-                        ->withUserInfo('')
-                        ->__toString();
-            }, $record->context),
+            array_map(self::contextItemToMessage(...), $record->context),
             $record->extra,
             $record->formatted,
         );
+    }
+
+    private static function contextItemToMessage(mixed $item): mixed
+    {
+        if (! $item instanceof RequestInterface) {
+            return $item;
+        }
+
+        return $item->getMethod()
+            . ' '
+            . $item
+                ->getUri()
+                ->withUserInfo('')
+                ->__toString();
     }
 }

--- a/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpRequestsIntoStrings.php
@@ -8,6 +8,8 @@ use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 use Psr\Http\Message\RequestInterface;
 
+use function array_map;
+
 /** @internal */
 final class ConvertLogContextHttpRequestsIntoStrings implements ProcessorInterface
 {
@@ -31,7 +33,7 @@ final class ConvertLogContextHttpRequestsIntoStrings implements ProcessorInterfa
                         ->__toString();
             }, $record->context),
             $record->extra,
-            $record->formatted
+            $record->formatted,
         );
     }
 }

--- a/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
@@ -20,20 +20,23 @@ final class ConvertLogContextHttpResponsesIntoStrings implements ProcessorInterf
             $record->channel,
             $record->level,
             $record->message,
-            array_map(static function ($item): mixed {
-                if (! $item instanceof ResponseInterface) {
-                    return $item;
-                }
-
-                return $item->getStatusCode()
-                    . ' "'
-                    . $item
-                        ->getBody()
-                        ->__toString()
-                    . '"';
-            }, $record->context),
+            array_map(self::contextItemToMessage(...), $record->context),
             $record->extra,
             $record->formatted,
         );
+    }
+
+    private static function contextItemToMessage(mixed $item): mixed
+    {
+        if (! $item instanceof ResponseInterface) {
+            return $item;
+        }
+
+        return $item->getStatusCode()
+            . ' "'
+            . $item
+                ->getBody()
+                ->__toString()
+            . '"';
     }
 }

--- a/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Monolog;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/** @internal */
+final class ConvertLogContextHttpResponsesIntoStrings implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        return new LogRecord(
+            $record->datetime,
+            $record->channel,
+            $record->level,
+            $record->message,
+            array_map(static function ($item): mixed {
+                if (! $item instanceof ResponseInterface) {
+                    return $item;
+                }
+
+                return $item->getStatusCode()
+                    . ' "'
+                    . $item
+                        ->getBody()
+                        ->__toString()
+                    . '"';
+            }, $record->context),
+            $record->extra,
+            $record->formatted
+        );
+    }
+}

--- a/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
+++ b/src/Monolog/ConvertLogContextHttpResponsesIntoStrings.php
@@ -8,6 +8,8 @@ use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use function array_map;
+
 /** @internal */
 final class ConvertLogContextHttpResponsesIntoStrings implements ProcessorInterface
 {
@@ -31,7 +33,7 @@ final class ConvertLogContextHttpResponsesIntoStrings implements ProcessorInterf
                     . '"';
             }, $record->context),
             $record->extra,
-            $record->formatted
+            $record->formatted,
         );
     }
 }

--- a/test/unit/HttpClient/LoggingHttpClientTest.php
+++ b/test/unit/HttpClient/LoggingHttpClientTest.php
@@ -6,12 +6,9 @@ namespace Laminas\AutomaticReleases\Test\Unit\HttpClient;
 
 use Http\Discovery\Psr17FactoryDiscovery;
 use Laminas\AutomaticReleases\HttpClient\LoggingHttpClient;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
-use function fopen;
 
 /** @covers \Laminas\AutomaticReleases\HttpClient\LoggingHttpClient */
 final class LoggingHttpClientTest extends TestCase
@@ -48,7 +45,7 @@ final class LoggingHttpClientTest extends TestCase
         self::assertSame(
             $response,
             (new LoggingHttpClient($next, $logger))
-                ->sendRequest($request)
+                ->sendRequest($request),
         );
     }
 }

--- a/test/unit/HttpClient/LoggingHttpClientTest.php
+++ b/test/unit/HttpClient/LoggingHttpClientTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\HttpClient;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Laminas\AutomaticReleases\HttpClient\LoggingHttpClient;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+use function fopen;
+
+/** @covers \Laminas\AutomaticReleases\HttpClient\LoggingHttpClient */
+final class LoggingHttpClientTest extends TestCase
+{
+    public function testWillLogRequestAndResponse(): void
+    {
+        $request  = Psr17FactoryDiscovery::findRequestFactory()->createRequest('get', 'http://example.com/foo/bar');
+        $response = Psr17FactoryDiscovery::findResponseFactory()->createResponse(204);
+
+        $response->getBody()
+            ->write('hello world');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $next   = $this->createMock(ClientInterface::class);
+
+        $next->expects(self::once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($response);
+
+        $logger->expects(self::exactly(2))
+            ->method('debug')
+            ->withConsecutive(
+                ['Sending request {request}', ['request' => $request]],
+                [
+                    'Received response {response} to request {request}',
+                    [
+                        'request'  => $request,
+                        'response' => $response,
+                    ],
+                ],
+            );
+
+        self::assertSame(
+            $response,
+            (new LoggingHttpClient($next, $logger))
+                ->sendRequest($request)
+        );
+    }
+}

--- a/test/unit/Monolog/ConvertLogContextHttpRequestsIntoStringsTest.php
+++ b/test/unit/Monolog/ConvertLogContextHttpRequestsIntoStringsTest.php
@@ -38,7 +38,7 @@ final class ConvertLogContextHttpRequestsIntoStringsTest extends TestCase
                     'foo'               => 'bar',
                     'plain request'     => 'GET http://example.com/foo',
                     'sensitive request' => 'POST https://example.com/foo?bar=baz',
-                ]
+                ],
             ),
             (new ConvertLogContextHttpRequestsIntoStrings())(new LogRecord(
                 $date,
@@ -49,8 +49,8 @@ final class ConvertLogContextHttpRequestsIntoStringsTest extends TestCase
                     'foo'               => 'bar',
                     'plain request'     => $plainRequest,
                     'sensitive request' => $sensitiveRequest,
-                ]
-            ))
+                ],
+            )),
         );
     }
 }

--- a/test/unit/Monolog/ConvertLogContextHttpRequestsIntoStringsTest.php
+++ b/test/unit/Monolog/ConvertLogContextHttpRequestsIntoStringsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Monolog;
+
+use DateTimeImmutable;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings */
+final class ConvertLogContextHttpRequestsIntoStringsTest extends TestCase
+{
+    public function testWillScrubSensitiveRequestInformation(): void
+    {
+        $date = new DateTimeImmutable();
+
+        $requestFactory = Psr17FactoryDiscovery::findRequestFactory();
+
+        $plainRequest = $requestFactory->createRequest('GET', 'http://example.com/foo');
+
+        $sensitiveRequest = $requestFactory->createRequest('POST', 'https://user:pass@example.com/foo?bar=baz')
+            ->withAddedHeader('Authentication', ['also secret']);
+
+        $sensitiveRequest->getBody()
+            ->write('super: secret');
+
+        self::assertEquals(
+            new LogRecord(
+                $date,
+                'a-channel',
+                Level::Critical,
+                'a message',
+                [
+                    'foo'               => 'bar',
+                    'plain request'     => 'GET http://example.com/foo',
+                    'sensitive request' => 'POST https://example.com/foo?bar=baz',
+                ]
+            ),
+            (new ConvertLogContextHttpRequestsIntoStrings())(new LogRecord(
+                $date,
+                'a-channel',
+                Level::Critical,
+                'a message',
+                [
+                    'foo'               => 'bar',
+                    'plain request'     => $plainRequest,
+                    'sensitive request' => $sensitiveRequest,
+                ]
+            ))
+        );
+    }
+}

--- a/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
+++ b/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Monolog;
+
+use DateTimeImmutable;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Laminas\AutomaticReleases\HttpClient\LoggingHttpClient;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use function fopen;
+
+/** @covers \Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings */
+final class ConvertLogContextHttpResponsesIntoStringsTest extends TestCase
+{
+    public function testWillScrubSensitiveRequestInformation(): void
+    {
+        $date = new DateTimeImmutable();
+
+        $requestFactory = Psr17FactoryDiscovery::findResponseFactory();
+
+        $plainResponse = $requestFactory->createResponse(401);
+
+        $sensitiveResponse = $requestFactory->createResponse(403)
+            ->withAddedHeader('Super', 'secret');
+
+        $sensitiveResponse->getBody()
+            ->write('this should be printed');
+
+        self::assertEquals(
+            new LogRecord(
+                $date,
+                'a-channel',
+                Level::Critical,
+                'a message',
+                [
+                    'foo'               => 'bar',
+                    'plain response'     => '401 ""',
+                    'sensitive response' => '403 "this should be printed"',
+                ]
+            ),
+            (new ConvertLogContextHttpResponsesIntoStrings())(new LogRecord(
+                $date,
+                'a-channel',
+                Level::Critical,
+                'a message',
+                [
+                    'foo'               => 'bar',
+                    'plain response'     => $plainResponse,
+                    'sensitive response' => $sensitiveResponse,
+                ]
+            ))
+        );
+    }
+}

--- a/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
+++ b/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
@@ -6,16 +6,10 @@ namespace Laminas\AutomaticReleases\Test\Unit\Monolog;
 
 use DateTimeImmutable;
 use Http\Discovery\Psr17FactoryDiscovery;
-use Laminas\AutomaticReleases\HttpClient\LoggingHttpClient;
-use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings;
 use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings;
-use Monolog\Handler\StreamHandler;
 use Monolog\Level;
-use Monolog\Logger;
 use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Client\ClientInterface;
-use function fopen;
 
 /** @covers \Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings */
 final class ConvertLogContextHttpResponsesIntoStringsTest extends TestCase
@@ -44,7 +38,7 @@ final class ConvertLogContextHttpResponsesIntoStringsTest extends TestCase
                     'foo'               => 'bar',
                     'plain response'     => '401 ""',
                     'sensitive response' => '403 "this should be printed"',
-                ]
+                ],
             ),
             (new ConvertLogContextHttpResponsesIntoStrings())(new LogRecord(
                 $date,
@@ -55,8 +49,8 @@ final class ConvertLogContextHttpResponsesIntoStringsTest extends TestCase
                     'foo'               => 'bar',
                     'plain response'     => $plainResponse,
                     'sensitive response' => $sensitiveResponse,
-                ]
-            ))
+                ],
+            )),
         );
     }
 }

--- a/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
+++ b/test/unit/Monolog/ConvertLogContextHttpResponsesIntoStringsTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 /** @covers \Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings */
 final class ConvertLogContextHttpResponsesIntoStringsTest extends TestCase
 {
-    public function testWillScrubSensitiveRequestInformation(): void
+    public function testWillScrubSensitiveResponseInformationAndRenderBody(): void
     {
         $date = new DateTimeImmutable();
 

--- a/test/unit/Monolog/VerifyLoggingIntegrationTest.php
+++ b/test/unit/Monolog/VerifyLoggingIntegrationTest.php
@@ -10,7 +10,10 @@ use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+
 use function fopen;
+use function rewind;
+use function stream_get_contents;
 
 /**
  * Small integration test to ensure future compatibility with monolog in our setup.
@@ -37,7 +40,7 @@ final class VerifyLoggingIntegrationTest extends TestCase
             [
                 new ConvertLogContextHttpRequestsIntoStrings(),
                 new ConvertLogContextHttpResponsesIntoStrings(),
-            ]
+            ],
         );
 
         $logger->debug('message', ['request' => $request, 'response' => $response]);
@@ -47,7 +50,7 @@ final class VerifyLoggingIntegrationTest extends TestCase
         self::assertStringContainsString(
             ': message {"request":"GET http://example.com/foo/bar","response":"204 \"hello world\""} []',
             stream_get_contents($stream),
-            'Request and response contents have been serialized into the final log message'
+            'Request and response contents have been serialized into the final log message',
         );
     }
 }

--- a/test/unit/Monolog/VerifyLoggingIntegrationTest.php
+++ b/test/unit/Monolog/VerifyLoggingIntegrationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Monolog;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpRequestsIntoStrings;
+use Laminas\AutomaticReleases\Monolog\ConvertLogContextHttpResponsesIntoStrings;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use function fopen;
+
+/**
+ * Small integration test to ensure future compatibility with monolog in our setup.
+ *
+ * @coversNothing
+ */
+final class VerifyLoggingIntegrationTest extends TestCase
+{
+    public function testLoggedRequestAndResponseBodyPartsDoNotContainSecretsAndPostData(): void
+    {
+        $request  = Psr17FactoryDiscovery::findRequestFactory()->createRequest('get', 'http://example.com/foo/bar');
+        $response = Psr17FactoryDiscovery::findResponseFactory()->createResponse(204);
+
+        $response->getBody()
+            ->write('hello world');
+
+        $stream = fopen('php://memory', 'rwb+');
+
+        $bufferHandler = new StreamHandler($stream);
+
+        $logger = new Logger(
+            'test-logger',
+            [$bufferHandler],
+            [
+                new ConvertLogContextHttpRequestsIntoStrings(),
+                new ConvertLogContextHttpResponsesIntoStrings(),
+            ]
+        );
+
+        $logger->debug('message', ['request' => $request, 'response' => $response]);
+
+        rewind($stream);
+
+        self::assertStringContainsString(
+            ': message {"request":"GET http://example.com/foo/bar","response":"204 \"hello world\""} []',
+            stream_get_contents($stream),
+            'Request and response contents have been serialized into the final log message'
+        );
+    }
+}

--- a/test/unit/Monolog/VerifyLoggingIntegrationTest.php
+++ b/test/unit/Monolog/VerifyLoggingIntegrationTest.php
@@ -24,7 +24,7 @@ final class VerifyLoggingIntegrationTest extends TestCase
 {
     public function testMonologProducedMessageStructureMatchesLogProcessorExpectations(): void
     {
-        $request  = Psr17FactoryDiscovery::findRequestFactory()->createRequest('get', 'http://example.com/foo/bar');
+        $request  = Psr17FactoryDiscovery::findRequestFactory()->createRequest('GET', 'http://example.com/foo/bar');
         $response = Psr17FactoryDiscovery::findResponseFactory()->createResponse(204);
 
         $response->getBody()

--- a/test/unit/Monolog/VerifyLoggingIntegrationTest.php
+++ b/test/unit/Monolog/VerifyLoggingIntegrationTest.php
@@ -22,7 +22,7 @@ use function stream_get_contents;
  */
 final class VerifyLoggingIntegrationTest extends TestCase
 {
-    public function testLoggedRequestAndResponseBodyPartsDoNotContainSecretsAndPostData(): void
+    public function testMonologProducedMessageStructureMatchesLogProcessorExpectations(): void
     {
         $request  = Psr17FactoryDiscovery::findRequestFactory()->createRequest('get', 'http://example.com/foo/bar');
         $response = Psr17FactoryDiscovery::findResponseFactory()->createResponse(204);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

This patch introduces general logging for:

 * HTTP requests sent to GitHub
 * HTTP responses received from GitHub

This can become a bit verbose, but verbosity could be adjusted later on, if needed: for now, we need this to figure out when/if things go wrong during a release, which is more important than clean output. 
