### PR TITLE
Enable debug mode for GitHub Actions

### DIFF
--- a/src/Environment/EnvironmentVariables.php
+++ b/src/Environment/EnvironmentVariables.php
@@ -6,10 +6,11 @@ namespace Laminas\AutomaticReleases\Environment;
 
 use Laminas\AutomaticReleases\Gpg\ImportGpgKeyFromString;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
-use Psl;
-use Psl\Env;
-use Psl\Iter;
-use Psl\Str;
+
+use function Psl\Env\get_var;
+use function Psl\invariant;
+use function Psl\Iter\contains;
+use function Psl\Str\format;
 
 /** @psalm-immutable */
 class EnvironmentVariables implements Variables
@@ -51,8 +52,8 @@ class EnvironmentVariables implements Variables
         private readonly string $logLevel,
     ) {
         /** @psalm-suppress ImpureFunctionCall the {@see \Psl\Iter\contains()} API is conditionally pure */
-        Psl\invariant(
-            Iter\contains(self::LOG_LEVELS, $logLevel),
+        invariant(
+            contains(self::LOG_LEVELS, $logLevel),
             'LOG_LEVEL env MUST be a valid monolog/monolog log level constant name or value;'
             . ' see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels',
         );
@@ -62,13 +63,21 @@ class EnvironmentVariables implements Variables
     {
         return new self(
             self::getenv('GITHUB_TOKEN'),
-            $importKey->__invoke(self::getenv('SIGNING_SECRET_KEY')),
+            ($importKey)(self::getenv('SIGNING_SECRET_KEY')),
             self::getenv('GIT_AUTHOR_NAME'),
             self::getenv('GIT_AUTHOR_EMAIL'),
             self::getenv('GITHUB_EVENT_PATH'),
             self::getenv('GITHUB_WORKSPACE'),
-            self::getenvWithFallback('LOG_LEVEL', 'INFO'),
+            self::getenvWithFallback(
+                'LOG_LEVEL',
+                self::isDebugMode() ? 'DEBUG' : 'INFO',
+            ),
         );
+    }
+
+    private static function isDebugMode(): bool
+    {
+        return get_var('ACTIONS_RUNNER_DEBUG') !== null;
     }
 
     /**
@@ -78,9 +87,9 @@ class EnvironmentVariables implements Variables
      */
     private static function getenv(string $key): string
     {
-        $value = Env\get_var($key);
+        $value = get_var($key);
 
-        Psl\invariant($value !== null && $value !== '', Str\format('Could not find a value for environment variable "%s"', $key));
+        invariant($value !== null && $value !== '', format('Could not find a value for environment variable "%s"', $key));
 
         return $value;
     }
@@ -93,7 +102,7 @@ class EnvironmentVariables implements Variables
      */
     private static function getenvWithFallback(string $key, string $default): string
     {
-        $value = Env\get_var($key);
+        $value = get_var($key);
 
         return $value === null || $value === '' ? $default : $value;
     }
@@ -120,7 +129,6 @@ class EnvironmentVariables implements Variables
 
     public function githubEventPath(): string
     {
-        // @TODO test me
         return $this->githubEventPath;
     }
 

--- a/test/unit/Environment/EnvironmentVariablesTest.php
+++ b/test/unit/Environment/EnvironmentVariablesTest.php
@@ -112,4 +112,40 @@ final class EnvironmentVariablesTest extends TestCase
 
         EnvironmentVariables::fromEnvironment($importKey);
     }
+
+    public function testDebugModeOffEnvironmentVariables(): void
+    {
+        // commented to signify a missing env variable.
+        // Env\set_var('ACTIONS_RUNNER_DEBUG', '');
+        Env\set_var('GITHUB_TOKEN', 'token');
+        Env\set_var('SIGNING_SECRET_KEY', 'aaa');
+        Env\set_var('GITHUB_ORGANISATION', 'bbb');
+        Env\set_var('GIT_AUTHOR_NAME', 'ccc');
+        Env\set_var('GIT_AUTHOR_EMAIL', 'ddd@eee.ff');
+        Env\set_var('GITHUB_EVENT_PATH', '/tmp/event');
+        Env\set_var('GITHUB_WORKSPACE', '/tmp');
+
+        $importKey = $this->createMock(ImportGpgKeyFromString::class);
+        $importKey->method('__invoke')->willReturn(SecretKeyId::fromBase16String('aabbccdd'));
+        $variables = EnvironmentVariables::fromEnvironment($importKey);
+        self::assertEquals('INFO', $variables->logLevel());
+    }
+
+    public function testDebugModeOnEnvironmentVariables(): void
+    {
+        Env\set_var('ACTIONS_RUNNER_DEBUG', 'TRUE');
+        Env\set_var('GITHUB_TOKEN', 'token');
+        Env\set_var('SIGNING_SECRET_KEY', 'aaa');
+        Env\set_var('GITHUB_ORGANISATION', 'bbb');
+        Env\set_var('GIT_AUTHOR_NAME', 'ccc');
+        Env\set_var('GIT_AUTHOR_EMAIL', 'ddd@eee.ff');
+        Env\set_var('GITHUB_EVENT_PATH', '/tmp/event');
+        Env\set_var('GITHUB_WORKSPACE', '/tmp');
+
+        $importKey = $this->createMock(ImportGpgKeyFromString::class);
+        $importKey->method('__invoke')->willReturn(SecretKeyId::fromBase16String('aabbccdd'));
+        $variables = EnvironmentVariables::fromEnvironment($importKey);
+
+        self::assertEquals('DEBUG', $variables->logLevel());
+    }
 }


### PR DESCRIPTION
- Check if the environment variable `ACTIONS_RUNNER_DEBUG ` is present, to set the log level to `DEBUG` mode via GitHub Actions.
- Note: it does not overwrite the default `LOG_LEVEL` environment variable.