### PR TITLE
Skip creating GIT tag if one already exists, enabling re-running of the action if a release creation fails

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -24,6 +24,7 @@ use Laminas\AutomaticReleases\Git\CommitFileViaConsole;
 use Laminas\AutomaticReleases\Git\CreateTagViaConsole;
 use Laminas\AutomaticReleases\Git\FetchAndSetCurrentUserByReplacingCurrentOriginRemote;
 use Laminas\AutomaticReleases\Git\GetMergeTargetCandidateBranchesFromRemoteBranches;
+use Laminas\AutomaticReleases\Git\HasTagViaConsole;
 use Laminas\AutomaticReleases\Git\PushViaConsole;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\Query\GetMilestoneFirst100IssuesAndPullRequests;
 use Laminas\AutomaticReleases\Github\Api\GraphQL\RunGraphQLQuery;
@@ -127,7 +128,7 @@ use const STDERR;
             $getMilestone,
             $commitChangelog,
             $createReleaseText,
-            new CreateTagViaConsole(),
+            new CreateTagViaConsole(new HasTagViaConsole()),
             $push,
             $createRelease,
         ),

--- a/bin/console.php
+++ b/bin/console.php
@@ -128,7 +128,7 @@ use const STDERR;
             $getMilestone,
             $commitChangelog,
             $createReleaseText,
-            new CreateTagViaConsole(new HasTagViaConsole()),
+            new CreateTagViaConsole(new HasTagViaConsole(), $logger),
             $push,
             $createRelease,
         ),

--- a/src/Git/CreateTag.php
+++ b/src/Git/CreateTag.php
@@ -9,7 +9,10 @@ use Laminas\AutomaticReleases\Gpg\SecretKeyId;
 
 interface CreateTag
 {
-    /** @param non-empty-string $repositoryDirectory */
+    /**
+     * @param non-empty-string $repositoryDirectory
+     * @param non-empty-string $tagName
+     */
     public function __invoke(
         string $repositoryDirectory,
         BranchName $sourceBranch,

--- a/src/Git/CreateTagViaConsole.php
+++ b/src/Git/CreateTagViaConsole.php
@@ -10,13 +10,16 @@ use Psl\Env;
 use Psl\File;
 use Psl\Filesystem;
 use Psl\Shell;
+use Psr\Log\LoggerInterface;
 
 use function sprintf;
 
 final class CreateTagViaConsole implements CreateTag
 {
-    public function __construct(private HasTag $hasTag)
-    {
+    public function __construct(
+        private readonly HasTag $hasTag,
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public function __invoke(
@@ -26,7 +29,11 @@ final class CreateTagViaConsole implements CreateTag
         string $changelog,
         SecretKeyId $keyId,
     ): void {
-        if (($this->hasTag)($repositoryDirectory, $tagName) === true) {
+        if (($this->hasTag)($repositoryDirectory, $tagName)) {
+            $this->logger->info(
+                sprintf('[CreateTagViaConsole] Skipping this step; tag "%s" already exists.', $tagName),
+            );
+
             return;
         }
 

--- a/src/Git/CreateTagViaConsole.php
+++ b/src/Git/CreateTagViaConsole.php
@@ -6,13 +6,18 @@ namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
-use Psl\Env;
-use Psl\File;
-use Psl\Filesystem;
-use Psl\Shell;
+
+use function Psl\Env\temp_dir;
+use function Psl\File\write;
+use function Psl\Filesystem\create_temporary_file;
+use function Psl\Shell\execute;
 
 final class CreateTagViaConsole implements CreateTag
 {
+    public function __construct(private HasTag $hasTag)
+    {
+    }
+
     public function __invoke(
         string $repositoryDirectory,
         BranchName $sourceBranch,
@@ -20,11 +25,20 @@ final class CreateTagViaConsole implements CreateTag
         string $changelog,
         SecretKeyId $keyId,
     ): void {
-        $tagFileName = Filesystem\create_temporary_file(Env\temp_dir(), 'created_tag');
+        if (($this->hasTag)($repositoryDirectory, $tagName) === true) {
+            return;
+        }
 
-        File\write($tagFileName, $changelog);
+        $tagFileName = create_temporary_file(temp_dir(), 'created_tag');
 
-        Shell\execute('git', ['checkout', $sourceBranch->name()], $repositoryDirectory);
-        Shell\execute('git', ['tag', $tagName, '-F', $tagFileName, '--cleanup=whitespace', '--local-user=' . $keyId->id()], $repositoryDirectory);
+        write($tagFileName, $changelog);
+
+        execute('git', ['checkout', $sourceBranch->name()], $repositoryDirectory);
+
+        execute(
+            'git',
+            ['tag', $tagName, '-F', $tagFileName, '--cleanup=whitespace', '--local-user=' . $keyId->id()],
+            $repositoryDirectory,
+        );
     }
 }

--- a/src/Git/CreateTagViaConsole.php
+++ b/src/Git/CreateTagViaConsole.php
@@ -6,11 +6,12 @@ namespace Laminas\AutomaticReleases\Git;
 
 use Laminas\AutomaticReleases\Git\Value\BranchName;
 use Laminas\AutomaticReleases\Gpg\SecretKeyId;
+use Psl\Env;
+use Psl\File;
+use Psl\Filesystem;
+use Psl\Shell;
 
-use function Psl\Env\temp_dir;
-use function Psl\File\write;
-use function Psl\Filesystem\create_temporary_file;
-use function Psl\Shell\execute;
+use function sprintf;
 
 final class CreateTagViaConsole implements CreateTag
 {
@@ -29,13 +30,13 @@ final class CreateTagViaConsole implements CreateTag
             return;
         }
 
-        $tagFileName = create_temporary_file(temp_dir(), 'created_tag');
+        $tagFileName = Filesystem\create_temporary_file(Env\temp_dir(), 'created_tag');
 
-        write($tagFileName, $changelog);
+        File\write($tagFileName, $changelog);
 
-        execute('git', ['checkout', $sourceBranch->name()], $repositoryDirectory);
+        Shell\execute('git', ['checkout', $sourceBranch->name()], $repositoryDirectory);
 
-        execute(
+        Shell\execute(
             'git',
             ['tag', $tagName, '-F', $tagFileName, '--cleanup=whitespace', '--local-user=' . $keyId->id()],
             $repositoryDirectory,

--- a/src/Git/HasTag.php
+++ b/src/Git/HasTag.php
@@ -6,7 +6,10 @@ namespace Laminas\AutomaticReleases\Git;
 
 interface HasTag
 {
-    /** @param non-empty-string $repositoryDirectory */
+    /**
+     * @param non-empty-string $repositoryDirectory
+     * @param non-empty-string $tagName
+     */
     public function __invoke(
         string $repositoryDirectory,
         string $tagName,

--- a/src/Git/HasTag.php
+++ b/src/Git/HasTag.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Git;
+
+interface HasTag
+{
+    /** @param non-empty-string $repositoryDirectory */
+    public function __invoke(
+        string $repositoryDirectory,
+        string $tagName,
+    ): bool;
+}

--- a/src/Git/HasTagViaConsole.php
+++ b/src/Git/HasTagViaConsole.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Git;
+
+use function Psl\Shell\execute;
+use function str_contains;
+use function trim;
+
+final class HasTagViaConsole implements HasTag
+{
+    public function __invoke(string $repositoryDirectory, string $tagName): bool
+    {
+        $outout = execute('git', ['tag', '--list', $tagName], $repositoryDirectory);
+
+        if (trim($outout) === '') {
+            return false;
+        }
+
+        return str_contains($outout, $tagName);
+    }
+}

--- a/src/Git/HasTagViaConsole.php
+++ b/src/Git/HasTagViaConsole.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\AutomaticReleases\Git;
 
-use function Psl\Shell\execute;
+use Psl\Shell;
+
 use function str_contains;
 use function trim;
 
@@ -12,12 +13,12 @@ final class HasTagViaConsole implements HasTag
 {
     public function __invoke(string $repositoryDirectory, string $tagName): bool
     {
-        $outout = execute('git', ['tag', '--list', $tagName], $repositoryDirectory);
+        $output = Shell\execute('git', ['tag', '--list', $tagName], $repositoryDirectory);
 
-        if (trim($outout) === '') {
+        if (trim($output) === '') {
             return false;
         }
 
-        return str_contains($outout, $tagName);
+        return str_contains($output, $tagName);
     }
 }

--- a/test/unit/Git/HasTagViaConsoleTest.php
+++ b/test/unit/Git/HasTagViaConsoleTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\AutomaticReleases\Test\Unit\Git;
+
+use Laminas\AutomaticReleases\Git\HasTag;
+use Laminas\AutomaticReleases\Git\HasTagViaConsole;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function Psl\Env\temp_dir;
+use function Psl\Filesystem\create_directory;
+use function Psl\Filesystem\create_temporary_file;
+use function Psl\Filesystem\delete_file;
+use function Psl\Shell\execute;
+use function sprintf;
+
+/** @covers \Laminas\AutomaticReleases\Git\HasTagViaConsole */
+final class HasTagViaConsoleTest extends TestCase
+{
+    /** @var non-empty-string */
+    private string $repository;
+    private HasTag $hasTag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = create_temporary_file(temp_dir(), 'HasTagViaConsoleRepository');
+
+        $this->hasTag = new HasTagViaConsole();
+
+        delete_file($this->repository);
+        create_directory($this->repository);
+
+        execute('git', ['init'], $this->repository);
+
+        execute('git', ['config', 'user.email', 'me@example.com'], $this->repository);
+        execute('git', ['config', 'user.name', 'Just Me'], $this->repository);
+
+        array_map(fn (string $tag) => $this->createTag($tag), [
+            '1.0.0',
+            '2.0.0',
+        ]);
+    }
+
+    private function createTag(string $tag): void
+    {
+        execute('git', ['commit', '--allow-empty', '-m', 'a commit for version ' . $tag], $this->repository);
+        execute('git', ['tag', '-a', $tag, '-m', 'version ' . $tag], $this->repository);
+    }
+
+    /** @param non-empty-string $repository */
+    private function assertGitTagExists(string $repository, string $tag): void
+    {
+        self::assertTrue(($this->hasTag)($repository, $tag), sprintf('Failed asserting git tag "%s" exists.', $tag));
+    }
+
+    /** @param non-empty-string $repository */
+    private function assertGitTagMissing(string $repository, string $tag): void
+    {
+        self::assertFalse(($this->hasTag)($repository, $tag), sprintf('Failed asserting git tag "%s" is missing.', $tag));
+    }
+
+    public function testHasTag(): void
+    {
+        self::assertGitTagExists($this->repository, '1.0.0');
+    }
+
+    public function testHasTagMissing(): void
+    {
+        self::assertGitTagMissing($this->repository, '10.0.0');
+    }
+}

--- a/test/unit/Git/HasTagViaConsoleTest.php
+++ b/test/unit/Git/HasTagViaConsoleTest.php
@@ -7,13 +7,11 @@ namespace Laminas\AutomaticReleases\Test\Unit\Git;
 use Laminas\AutomaticReleases\Git\HasTag;
 use Laminas\AutomaticReleases\Git\HasTagViaConsole;
 use PHPUnit\Framework\TestCase;
+use Psl\Env;
+use Psl\Filesystem;
+use Psl\Shell;
 
 use function array_map;
-use function Psl\Env\temp_dir;
-use function Psl\Filesystem\create_directory;
-use function Psl\Filesystem\create_temporary_file;
-use function Psl\Filesystem\delete_file;
-use function Psl\Shell\execute;
 use function sprintf;
 
 /** @covers \Laminas\AutomaticReleases\Git\HasTagViaConsole */
@@ -27,17 +25,17 @@ final class HasTagViaConsoleTest extends TestCase
     {
         parent::setUp();
 
-        $this->repository = create_temporary_file(temp_dir(), 'HasTagViaConsoleRepository');
+        $this->repository = Filesystem\create_temporary_file(Env\temp_dir(), 'HasTagViaConsoleRepository');
 
         $this->hasTag = new HasTagViaConsole();
 
-        delete_file($this->repository);
-        create_directory($this->repository);
+        Filesystem\delete_file($this->repository);
+        Filesystem\create_directory($this->repository);
 
-        execute('git', ['init'], $this->repository);
+        Shell\execute('git', ['init'], $this->repository);
 
-        execute('git', ['config', 'user.email', 'me@example.com'], $this->repository);
-        execute('git', ['config', 'user.name', 'Just Me'], $this->repository);
+        Shell\execute('git', ['config', 'user.email', 'me@example.com'], $this->repository);
+        Shell\execute('git', ['config', 'user.name', 'Just Me'], $this->repository);
 
         array_map(fn (string $tag) => $this->createTag($tag), [
             '1.0.0',
@@ -47,17 +45,23 @@ final class HasTagViaConsoleTest extends TestCase
 
     private function createTag(string $tag): void
     {
-        execute('git', ['commit', '--allow-empty', '-m', 'a commit for version ' . $tag], $this->repository);
-        execute('git', ['tag', '-a', $tag, '-m', 'version ' . $tag], $this->repository);
+        Shell\execute('git', ['commit', '--allow-empty', '-m', 'a commit for version ' . $tag], $this->repository);
+        Shell\execute('git', ['tag', '-a', $tag, '-m', 'version ' . $tag], $this->repository);
     }
 
-    /** @param non-empty-string $repository */
+    /**
+     * @param non-empty-string $repository
+     * @param non-empty-string $tag
+     */
     private function assertGitTagExists(string $repository, string $tag): void
     {
         self::assertTrue(($this->hasTag)($repository, $tag), sprintf('Failed asserting git tag "%s" exists.', $tag));
     }
 
-    /** @param non-empty-string $repository */
+    /**
+     * @param non-empty-string $repository
+     * @param non-empty-string $tag
+     */
     private function assertGitTagMissing(string $repository, string $tag): void
     {
         self::assertFalse(($this->hasTag)($repository, $tag), sprintf('Failed asserting git tag "%s" is missing.', $tag));
@@ -65,11 +69,11 @@ final class HasTagViaConsoleTest extends TestCase
 
     public function testHasTag(): void
     {
-        self::assertGitTagExists($this->repository, '1.0.0');
+        $this->assertGitTagExists($this->repository, '1.0.0');
     }
 
     public function testHasTagMissing(): void
     {
-        self::assertGitTagMissing($this->repository, '10.0.0');
+        $this->assertGitTagMissing($this->repository, '10.0.0');
     }
 }


### PR DESCRIPTION
Resolves #222