### PR TITLE
Fix creating minor release if new major release branch already exist

### DIFF
--- a/feature/automated-releases.feature
+++ b/feature/automated-releases.feature
@@ -38,7 +38,7 @@ Feature: Automated releases
     When I close milestone "2.0.0"
     Then tag "2.0.0" should have been created on branch "2.0.x"
 
-  Scenario: If a new major release branch exists, the tool does not create a new minor release
+  Scenario: If matching minor release branch exists, the tool does not create a new minor release
     Given following existing branches:
       | name    |
       | 1.0.x   |
@@ -65,6 +65,21 @@ Feature: Automated releases
     When I close milestone "1.1.0"
     Then tag "1.1.0" should have been created on branch "1.1.x"
     And a new pull request from branch "1.1.x" to "1.2.x" should have been created
+
+  Scenario: If a minor release branch exists, when closing the minor release milestone,
+  the tool tags the minor release from the branch, and creates a pull request
+  against the next newer minor or major release branch.
+    Given following existing branches:
+      | name   |
+      | 1.1.x  |
+      | 2.0.x  |
+      | master |
+    And following open milestones:
+      | name  |
+      | 1.1.0 |
+    When I close milestone "1.1.0"
+    Then tag "1.1.0" should have been created on branch "1.1.x"
+    And a new pull request from branch "1.1.x" to "2.0.x" should have been created
 
   Scenario: If no newer release branch exists, the tool will not create any pull requests
     Given following existing branches:

--- a/src/Application/Command/SwitchDefaultBranchToNextMinor.php
+++ b/src/Application/Command/SwitchDefaultBranchToNextMinor.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function sprintf;
+
 final class SwitchDefaultBranchToNextMinor extends Command
 {
     public function __construct(
@@ -58,9 +60,20 @@ final class SwitchDefaultBranchToNextMinor extends Command
         $nextDefaultBranch = $mergeCandidates->newestFutureReleaseBranchAfter($releaseVersion);
 
         if (! $mergeCandidates->contains($nextDefaultBranch)) {
+            $baseBranch = $mergeCandidates->targetBranchFor($releaseVersion);
+            if ($baseBranch === null) {
+                $output->writeln(sprintf(
+                    'Target branch for release [%s] was not found. Expected [%s] to exist.',
+                    $releaseVersion->fullReleaseName(),
+                    $releaseVersion->targetReleaseBranchName()->name(),
+                ));
+
+                return 1;
+            }
+
             $this->push->__invoke(
                 $repositoryPath,
-                $newestBranch->name(),
+                $baseBranch->name(),
                 $nextDefaultBranch->name(),
             );
             ($this->bumpChangelogVersion)(

--- a/src/Git/Value/SemVerVersion.php
+++ b/src/Git/Value/SemVerVersion.php
@@ -11,9 +11,9 @@ use Psl\Regex;
 final readonly class SemVerVersion
 {
     private function __construct(
-        private readonly int $major,
-        private readonly int $minor,
-        private readonly int $patch,
+        private int $major,
+        private int $minor,
+        private int $patch,
     ) {
     }
 

--- a/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
+++ b/test/unit/Application/SwitchDefaultBranchToNextMinorTest.php
@@ -145,6 +145,146 @@ final class SwitchDefaultBranchToNextMinorTest extends TestCase
         self::assertSame(0, $this->command->run(new ArrayInput([]), new NullOutput()));
     }
 
+    public function testWillSwitchToExistingNewestDefaultBranchEvenWithNewMajorBranchExist(): void
+    {
+        $event = MilestoneClosedEvent::fromEventJson(
+            <<<'JSON'
+            {
+                "milestone": {
+                    "title": "1.3.0",
+                    "number": 123
+                },
+                "repository": {
+                    "full_name": "foo/bar"
+                },
+                "action": "closed"
+            }
+            JSON,
+        );
+
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
+
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
+
+        $this->variables->method('githubWorkspacePath')
+            ->willReturn($workspace);
+
+        $this->loadEvent->method('__invoke')
+            ->willReturn($event);
+
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace,
+            );
+
+        $this->getMergeTargets->method('__invoke')
+            ->with($workspace)
+            ->willReturn(MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.2.x'),
+                BranchName::fromName('1.3.x'),
+                BranchName::fromName('2.0.x'),
+                BranchName::fromName('master'),
+            ));
+
+        $this->push->expects(self::once())
+            ->method('__invoke')
+            ->with($workspace, '1.3.x', '1.4.x');
+
+        $this->bumpChangelogVersion->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                BumpAndCommitChangelogVersion::BUMP_MINOR,
+                $workspace,
+                SemVerVersion::fromMilestoneName('1.3.0'),
+                BranchName::fromName('1.4.x'),
+            );
+
+        $this->setDefaultBranch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                self::equalTo(RepositoryName::fromFullName('foo/bar')),
+                self::equalTo(BranchName::fromName('1.4.x')),
+            );
+
+        self::assertSame(0, $this->command->run(new ArrayInput([]), new NullOutput()));
+    }
+
+    public function testWillNotSwitchToBranchWhenTargetBranchNotFound(): void
+    {
+        $event = MilestoneClosedEvent::fromEventJson(
+            <<<'JSON'
+            {
+                "milestone": {
+                    "title": "1.4.0",
+                    "number": 123
+                },
+                "repository": {
+                    "full_name": "foo/bar"
+                },
+                "action": "closed"
+            }
+            JSON,
+        );
+
+        $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');
+
+        Filesystem\delete_file($workspace);
+        Filesystem\create_directory($workspace);
+        Filesystem\create_directory($workspace . '/.git');
+
+        $this->variables->method('githubWorkspacePath')
+            ->willReturn($workspace);
+
+        $this->loadEvent->method('__invoke')
+            ->willReturn($event);
+
+        $this->fetch->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                'https://github.com/foo/bar.git',
+                'https://github-auth-token:x-oauth-basic@github.com/foo/bar.git',
+                $workspace,
+            );
+
+        $this->getMergeTargets->method('__invoke')
+            ->with($workspace)
+            ->willReturn(MergeTargetCandidateBranches::fromAllBranches(
+                BranchName::fromName('1.1.x'),
+                BranchName::fromName('1.2.x'),
+                BranchName::fromName('1.3.x'),
+                BranchName::fromName('2.0.x'),
+                BranchName::fromName('master'),
+            ));
+
+        $this->push->expects(self::never())
+            ->method('__invoke');
+
+        $this->bumpChangelogVersion->expects(self::never())
+            ->method('__invoke');
+
+        $this->setDefaultBranch->expects(self::never())
+            ->method('__invoke');
+
+        $output = new BufferedOutput();
+
+        self::assertSame(1, $this->command->run(new ArrayInput([]), $output));
+
+        self::assertSame(
+            <<<'OUTPUT'
+            Target branch for release [1.4.0] was not found. Expected [1.4.x] to exist.
+            
+            OUTPUT
+            ,
+            $output->fetch(),
+        );
+    }
+
     public function testWillSwitchToNewlyCreatedDefaultBranchWhenNoNewerReleaseBranchExists(): void
     {
         $workspace = Filesystem\create_temporary_file(Env\temp_dir(), 'workspace');


### PR DESCRIPTION


<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

This patch fixes the minor branch creation if already a new major branch exist. This is useful if a new major release is already in the work but new feature are still coming into the current latest major.

The case is as follows:
When we already have these branches: 1.0.x, 1.1.x, 1.2.x, 2.0.x And we release 1.2.0, then we expect that 1.3.x is created and set as a new default branch.
