### PR TITLE
Set GNUPGHOME to /tmp in the release image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,4 +18,19 @@ jobs:
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
 
       - name: "Docker Build"
-        run: "DOCKER_BUILDKIT=1 docker build ."
+        run: "DOCKER_BUILDKIT=1 docker build --tag 'automatic-releases:ci' ."
+
+      # Regression test for https://github.com/laminas/automatic-releases/issues/304: a job runs this image
+      # several times with the same $HOME volume, and the second GPG import used to time out on the state
+      # left behind by the first one.
+      - name: "Import a GPG key twice, as a release job does"
+        run: |
+          mkdir -p "${RUNNER_TEMP}/github-home"
+          for attempt in 1 2; do
+            timeout 120 docker run --rm \
+              --volume "${RUNNER_TEMP}/github-home:/github/home" \
+              --volume "${GITHUB_WORKSPACE}/test/asset:/asset:ro" \
+              --env "HOME=/github/home" \
+              --entrypoint gpg \
+              'automatic-releases:ci' --batch --import /asset/dummy-gpg-key.asc
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,15 @@ COPY src /app/src/
 
 RUN composer dump-autoload -a --no-dev
 
+# Keep the GnuPG state inside the container. In GitHub Actions $HOME is a volume shared by every step of a
+# job, so a GNUPGHOME under $HOME leaks from one step to the next: the imported private key stays readable
+# by later steps, and GnuPG 2.4 makes it worse by enabling keyboxd when it creates a default home directory,
+# leaving a database and a dead socket that make the next import time out. A directory created here is fresh
+# in every container, so no state is ever shared. As a bonus, GnuPG 2.4 leaves an existing GNUPGHOME on the
+# plain keyring instead of switching it to keyboxd.
+ENV GNUPGHOME=/gnupg
+RUN mkdir -m 0700 /gnupg
+
 ENV SHELL_VERBOSITY=3
 
 ENTRYPOINT ["/app/bin/console.php"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ COPY src /app/src/
 
 RUN composer dump-autoload -a --no-dev
 
+# Keep the GnuPG state inside the container so it does not leak through the shared $HOME volume.
+ENV GNUPGHOME=/tmp
+
 ENV SHELL_VERBOSITY=3
 
 ENTRYPOINT ["/app/bin/console.php"]


### PR DESCRIPTION
In GitHub Actions, `$HOME` is a volume shared by every step of a job, so the default GnuPG home (`$HOME/.gnupg`) leaks the imported private key to later steps, and GnuPG 2.4 leaves a `keyboxd` database and a dead socket that make the next import time out.

Setting `GNUPGHOME=/tmp` keeps the GnuPG state inside the container. `/tmp` is container-local, already exists, and stays writable under a read-only root filesystem, so no directory needs to be created.

Fixes #304